### PR TITLE
feat: add isPartOf to service output

### DIFF
--- a/avro/ServiceOutput.avsc
+++ b/avro/ServiceOutput.avsc
@@ -33,6 +33,11 @@
       "name": "type",
       "type": ["null", {"type": "array", "items": "no.digdir.fdk.model.ReferenceDataCode"}],
       "doc": "Type for the output"
+    },
+    {
+      "name": "isPartOf",
+      "type": ["null", {"type": "array", "items": "string"}],
+      "doc": "Datasets that the output can be part of (dct:isPartOf)"
     }
   ]
 }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/service/Output.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/service/Output.kt
@@ -2,6 +2,7 @@ package no.digdir.fdk.parserservice.extract.service
 
 import no.digdir.fdk.model.service.ServiceOutput
 import no.digdir.fdk.parserservice.extract.extractListOfReferenceDataCodes
+import no.digdir.fdk.parserservice.extract.extractListOfUriOrIdentifier
 import no.digdir.fdk.parserservice.extract.extractLocalizedStrings
 import no.digdir.fdk.parserservice.extract.extractStringValue
 import no.digdir.fdk.parserservice.extract.extractURIStringValue
@@ -20,6 +21,7 @@ private fun ServiceOutput.hasContent() =
         description != null -> true
         language != null -> true
         type != null -> true
+        isPartOf != null -> true
         else -> false
     }
 
@@ -33,6 +35,7 @@ private fun Resource.buildServiceOutput(): ServiceOutput? {
         .setDescription(extractLocalizedStrings(DCTerms.description))
         .setLanguage(extractListOfReferenceDataCodes(DCTerms.language, EUAT.authorityCode, SKOS.prefLabel))
         .setType(extractListOfReferenceDataCodes(DCTerms.type, "#", SKOS.prefLabel))
+        .setIsPartOf(extractListOfUriOrIdentifier(DCTerms.isPartOf))
 
     return builder.build().takeIf { it.hasContent() }
 }

--- a/src/test/kotlin/no/digdir/fdk/parserservice/extract/service/OutputExtractionTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/parserservice/extract/service/OutputExtractionTest.kt
@@ -34,7 +34,8 @@ class OutputExtractionTest {
                 dct:title       "Output name"@en ;
                 dct:description "Output description"@en ;
                 dct:language    <http://publications.europa.eu/resource/authority/language/ENG> ;
-                dct:type        <https://test.no/concept/1> .
+                dct:type        <https://test.no/concept/1> ;
+                dct:isPartOf    <https://test.no/dataset/1> .
 
             <http://publications.europa.eu/resource/authority/language/ENG>
                 a                  skos:Concept;
@@ -74,7 +75,8 @@ class OutputExtractionTest {
                                 prefLabel = LocalizedStrings().apply { en = "Output type" }
                             },
                         ),
-                    ).build(),
+                    ).setIsPartOf(listOf("https://test.no/dataset/1"))
+                    .build(),
             )
 
         assertEquals(expected, subject.extractListOfServiceOutput(CPSV.produces))

--- a/src/test/kotlin/no/digdir/fdk/parserservice/handler/ServiceHandlerTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/parserservice/handler/ServiceHandlerTest.kt
@@ -222,7 +222,8 @@ class ServiceHandlerTest {
                   }
                 }
               ],
-              "type": null
+              "type": null,
+              "isPartOf": null
             }
           ],
           "spatial": null,


### PR DESCRIPTION
# Summary

- Legg til isPartOf (array of string) i ServiceOutput Avro-skjema
- Ekstraher dct:isPartOf på tjenesteresultat som liste med datasett-URI-er
- Oppdater output-ekstraksjon- og handler-tester

Del av #1929.