### PR TITLE
feat: support multiple dataset dctType

### DIFF
--- a/avro/Dataset.avsc
+++ b/avro/Dataset.avsc
@@ -214,9 +214,12 @@
       "name": "dctType",
       "type": [
         "null",
-        "no.digdir.fdk.model.ReferenceDataCode"
+        {
+          "type": "array",
+          "items": "no.digdir.fdk.model.ReferenceDataCode"
+        }
       ],
-      "doc": "Type of dataset"
+      "doc": "List of dataset types from dct:type"
     },
     {
       "name": "accessRights",

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/dataset/BaseDatasetParser.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/dataset/BaseDatasetParser.kt
@@ -127,7 +127,7 @@ abstract class BaseDatasetParser : DatasetParserStrategy {
         setEurovocThemes(themeResources?.filter { isEurovocURI(it.uri) }?.mapNotNull { it.extractEurovoc() }?.takeIf { it.isNotEmpty() })
 
         setAccrualPeriodicity(datasetResource.extractReferenceDataCode(DCTerms.accrualPeriodicity, DC_11.identifier, SKOS.prefLabel))
-        setDctType(datasetResource.extractReferenceDataCode(DCTerms.type, DC_11.identifier, SKOS.prefLabel))
+        setDctType(datasetResource.extractListOfReferenceDataCodes(DCTerms.type, DC_11.identifier, SKOS.prefLabel))
         setProvenance(datasetResource.extractReferenceDataCode(DCTerms.provenance, EUAT.authorityCode, SKOS.prefLabel))
         setSpatial(datasetResource.extractListOfReferenceDataCodes(DCTerms.spatial, DCTerms.identifier, DCTerms.title))
         setConformsTo(datasetResource.extractListOfUriWithLabel(DCTerms.conformsTo, DCTerms.source, DCTerms.title))

--- a/src/test/kotlin/no/digdir/fdk/parserservice/extract/dataset/DatasetExtractionTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/parserservice/extract/dataset/DatasetExtractionTest.kt
@@ -494,7 +494,7 @@ class DatasetExtractionTest {
             assertEquals(expectedSpatial, result.spatial)
             assertEquals(expectedProvenance, result.provenance)
             assertEquals(expectedFrequency, result.accrualPeriodicity)
-            assertEquals(expectedType, result.dctType)
+            assertEquals(listOf(expectedType), result.dctType)
         }
 
         @Test


### PR DESCRIPTION
# Summary

- Emit dataset `dctType` as a list (0..n) instead of a single value
- `avro/Dataset.avsc`: `dctType` → array of `ReferenceDataCode` (mirrors `Event.avsc`)
- `BaseDatasetParser`: use `extractListOfReferenceDataCodes` (same predicate/code/label args)