### PR TITLE
chore: bump spring boot 4.1.0 and fix ktlint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,11 +4,22 @@ root = true
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[*.{kt,kts}]
-max_line_length = 140
+[*.md]
+trim_trailing_whitespace = false
 
 [*.{xml,yaml,yml,json}]
 indent_size = 2
+
+[*.{kt,kts}]
+ktlint_code_style = intellij_idea
+
+max_line_length = 140
+
+# No star imports
+ij_kotlin_packages_to_use_import_on_demand = unset
+ij_kotlin_name_count_to_use_star_import = 999
+ij_kotlin_name_count_to_use_star_import_for_members = 999

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.{kt,kts}]
+max_line_length = 140
+
+[*.{xml,yaml,yml,json}]
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -54,3 +54,12 @@ is only one schema in your registry.
 ```
 sh ./kafka/produce-messages.sh
 ```
+
+### Formatting code
+
+This project uses [ktlint](https://github.com/gantsign/ktlint-maven-plugin) to enforce a consistent code style.
+To automatically fix formatting violations, run:
+
+```sh
+mvn ktlint:format
+```

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.6</version>
+        <version>4.1.0</version>
         <relativePath/>
     </parent>
 
@@ -276,6 +276,12 @@
                 </executions>
             </plugin>
 
+            <!-- ktlint derives its source roots from the project's compile source roots.
+                 Those resolve to <sourceDirectory>/<testSourceDirectory> above, which point
+                 at src/main/kotlin and src/test/kotlin - that is what makes ktlint see the
+                 Kotlin sources. Do not repoint those without registering the Kotlin
+                 directories some other way (e.g. build-helper add-source), or ktlint
+                 silently degrades to inspecting no files while still reporting green. -->
             <plugin>
                 <groupId>com.github.gantsign.maven</groupId>
                 <artifactId>ktlint-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -276,21 +276,14 @@
                 </executions>
             </plugin>
 
-            <!-- ktlint derives its source roots from the project's compile source roots.
-                 Those resolve to <sourceDirectory>/<testSourceDirectory> above, which point
-                 at src/main/kotlin and src/test/kotlin - that is what makes ktlint see the
-                 Kotlin sources. Do not repoint those without registering the Kotlin
-                 directories some other way (e.g. build-helper add-source), or ktlint
-                 silently degrades to inspecting no files while still reporting green. -->
             <plugin>
                 <groupId>com.github.gantsign.maven</groupId>
                 <artifactId>ktlint-maven-plugin</artifactId>
                 <version>3.7.1</version>
                 <executions>
                     <execution>
-                        <id>format-and-check</id>
+                        <id>ktlint-check</id>
                         <goals>
-                            <goal>format</goal>
                             <goal>check</goal>
                         </goals>
                     </execution>

--- a/src/main/kotlin/no/digdir/fdk/parserservice/configuration/CircuitBreakerConsumerConfiguration.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/configuration/CircuitBreakerConsumerConfiguration.kt
@@ -14,9 +14,7 @@ import org.springframework.context.annotation.Configuration
 import java.time.Duration
 
 @Configuration
-class CircuitBreakerConsumerConfiguration(
-    private val kafkaManager: KafkaManager,
-) {
+class CircuitBreakerConsumerConfiguration(private val kafkaManager: KafkaManager) {
     private val circuitBreakerToListenerMapping =
         mapOf(
             "rdf-parse-concept" to "concept-event-consumer",
@@ -50,11 +48,7 @@ class CircuitBreakerConsumerConfiguration(
         return registry
     }
 
-    private fun configureCircuitBreaker(
-        registry: CircuitBreakerRegistry,
-        circuitBreakerName: String,
-        listenerId: String?,
-    ) {
+    private fun configureCircuitBreaker(registry: CircuitBreakerRegistry, circuitBreakerName: String, listenerId: String?) {
         if (listenerId != null) {
             KafkaParseMetrics.registerListenerPausedGauge(listenerId)
         }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/configuration/MetricsConfiguration.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/configuration/MetricsConfiguration.kt
@@ -10,10 +10,7 @@ import no.digdir.fdk.parserservice.metrics.RdfParseEventMetrics
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-class MetricsConfiguration(
-    private val circuitBreakerRegistry: CircuitBreakerRegistry,
-    private val meterRegistry: MeterRegistry,
-) {
+class MetricsConfiguration(private val circuitBreakerRegistry: CircuitBreakerRegistry, private val meterRegistry: MeterRegistry) {
     @PostConstruct
     fun bindMetrics() {
         ParseMetrics.bind(meterRegistry)

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/ContactPoint.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/ContactPoint.kt
@@ -5,17 +5,16 @@ import org.apache.jena.rdf.model.Resource
 import org.apache.jena.vocabulary.DCAT
 import org.apache.jena.vocabulary.VCARD4
 
-private fun ContactPoint.hasContent() =
-    when {
-        uri != null -> true
-        fullname != null -> true
-        email != null -> true
-        hasURL != null -> true
-        hasTelephone != null -> true
-        organizationName != null -> true
-        organizationUnit != null -> true
-        else -> false
-    }
+private fun ContactPoint.hasContent() = when {
+    uri != null -> true
+    fullname != null -> true
+    email != null -> true
+    hasURL != null -> true
+    hasTelephone != null -> true
+    organizationName != null -> true
+    organizationUnit != null -> true
+    else -> false
+}
 
 private fun Resource.extractVcardTelephone(): String? {
     val value =
@@ -57,7 +56,6 @@ private fun Resource.buildContactPoint(): ContactPoint? {
  *
  * @return list of contact points or `null` when no contact point information exists
  */
-fun Resource.extractListOfContactPoints(): List<ContactPoint>? =
-    listResources(DCAT.contactPoint)
-        ?.mapNotNull { it.buildContactPoint() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfContactPoints(): List<ContactPoint>? = listResources(DCAT.contactPoint)
+    ?.mapNotNull { it.buildContactPoint() }
+    ?.takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/Cost.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/Cost.kt
@@ -8,25 +8,23 @@ import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.DC_11
 import org.apache.jena.vocabulary.SKOS
 
-private fun Cost.hasContent() =
-    when {
-        identifier != null -> true
-        hasValue != null -> true
-        description != null -> true
-        documentation != null -> true
-        currency != null -> true
-        isDefinedBy != null -> true
-        else -> false
-    }
+private fun Cost.hasContent() = when {
+    identifier != null -> true
+    hasValue != null -> true
+    description != null -> true
+    documentation != null -> true
+    currency != null -> true
+    isDefinedBy != null -> true
+    else -> false
+}
 
-private fun Resource.builderWithCommonProperties(): Cost.Builder =
-    Cost
-        .newBuilder()
-        .setIdentifier(extractStringValue(DCTerms.identifier))
-        .setHasValue(extractStringValue(CV.hasValue))
-        .setDescription(extractLocalizedStrings(DCTerms.description))
-        .setDocumentation(extractListOfStrings(FOAF.page))
-        .setCurrency(extractReferenceDataCode(CV.currency, DC_11.identifier, SKOS.prefLabel))
+private fun Resource.builderWithCommonProperties(): Cost.Builder = Cost
+    .newBuilder()
+    .setIdentifier(extractStringValue(DCTerms.identifier))
+    .setHasValue(extractStringValue(CV.hasValue))
+    .setDescription(extractLocalizedStrings(DCTerms.description))
+    .setDocumentation(extractListOfStrings(FOAF.page))
+    .setCurrency(extractReferenceDataCode(CV.currency, DC_11.identifier, SKOS.prefLabel))
 
 private fun Resource.buildCost(): Cost? {
     val builder = builderWithCommonProperties()
@@ -44,12 +42,10 @@ private fun Resource.buildServiceCost(): Cost? {
     return builder.build().takeIf { it.hasContent() }
 }
 
-fun Resource.extractListOfCosts(): List<Cost>? =
-    listResources(CV.hasCost)
-        ?.mapNotNull { it.buildCost() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfCosts(): List<Cost>? = listResources(CV.hasCost)
+    ?.mapNotNull { it.buildCost() }
+    ?.takeIf { it.isNotEmpty() }
 
-fun Resource.extractListOfServiceCosts(): List<Cost>? =
-    listResources(CV.hasCost)
-        ?.mapNotNull { it.buildServiceCost() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfServiceCosts(): List<Cost>? = listResources(CV.hasCost)
+    ?.mapNotNull { it.buildServiceCost() }
+    ?.takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/Format.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/Format.kt
@@ -17,12 +17,11 @@ import org.apache.jena.vocabulary.RDF
  * @param pred the predicate that points to the format resource(s)
  * @return list of populated `Format` objects, or `null` when no values exist
  */
-fun Resource.extractListOfFormats(pred: Property): List<Format>? =
-    listProperties(pred)
-        .asSequence()
-        .mapNotNull { it.buildFormat() }
-        .toList()
-        .takeIf { it.isNotEmpty() }
+fun Resource.extractListOfFormats(pred: Property): List<Format>? = listProperties(pred)
+    .asSequence()
+    .mapNotNull { it.buildFormat() }
+    .toList()
+    .takeIf { it.isNotEmpty() }
 
 /**
  * Extracts a single format resource reachable via the predicate and maps it to a `Format`.

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/GenericRDF.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/GenericRDF.kt
@@ -42,13 +42,12 @@ fun Resource.singleObjectStatement(pred: Property): Statement? {
  * @return The resource object, or null if not found or not a resource
  * @see Resource.singleObjectStatement
  */
-fun Resource.singleResource(pred: Property): Resource? =
-    try {
-        singleObjectStatement(pred)?.resource?.takeIf { it.isResource }
-    } catch (ex: Exception) {
-        LOGGER.debug("Failed to extract ${pred.uri}, found on $uri, as resource", ex)
-        null
-    }
+fun Resource.singleResource(pred: Property): Resource? = try {
+    singleObjectStatement(pred)?.resource?.takeIf { it.isResource }
+} catch (ex: Exception) {
+    LOGGER.debug("Failed to extract ${pred.uri}, found on $uri, as resource", ex)
+    null
+}
 
 /**
  * Extension function to get a list of resources for a given predicate.
@@ -60,29 +59,27 @@ fun Resource.singleResource(pred: Property): Resource? =
  * @return List of resource objects, or null if extraction fails
  * @see Resource.listProperties
  */
-fun Resource.listResources(pred: Property): List<Resource>? =
-    try {
-        listProperties(pred)
-            .asSequence()
-            .map { it.resource }
-            .filter { it.isResource }
-            .toList()
-    } catch (ex: Exception) {
-        LOGGER.debug("Failed to extract ${pred.uri}, found on $uri, as resource", ex)
-        null
-    }
+fun Resource.listResources(pred: Property): List<Resource>? = try {
+    listProperties(pred)
+        .asSequence()
+        .map { it.resource }
+        .filter { it.isResource }
+        .toList()
+} catch (ex: Exception) {
+    LOGGER.debug("Failed to extract ${pred.uri}, found on $uri, as resource", ex)
+    null
+}
 
 /**
  * Extension function to extract string value from a resource.
  *
  * @return The string value, or null if the resource is not a URIResource or the URI is skolemized
  */
-fun Resource.extractURIStringValue(): String? =
-    if (isURIResource) {
-        uri?.takeIf { !isSkolemizedURI(it) }
-    } else {
-        null
-    }
+fun Resource.extractURIStringValue(): String? = if (isURIResource) {
+    uri?.takeIf { !isSkolemizedURI(it) }
+} else {
+    null
+}
 
 /**
  * Extension function to extract the string value of either the resource URI or dct:identifier.
@@ -103,10 +100,9 @@ fun Resource.extractUriOrIdentifier(pred: Property): String? = singleResource(pr
  *
  * @return List of URI or identifier values
  */
-fun Resource.extractListOfUriOrIdentifier(pred: Property): List<String>? =
-    listResources(pred)
-        ?.mapNotNull { it.extractUriOrIdentifier() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfUriOrIdentifier(pred: Property): List<String>? = listResources(pred)
+    ?.mapNotNull { it.extractUriOrIdentifier() }
+    ?.takeIf { it.isNotEmpty() }
 
 /**
  * Private extension function to extract string value from a statement.
@@ -144,13 +140,12 @@ fun Resource.extractStringValue(pred: Property): String? = singleObjectStatement
  * @return The integer value, or null if not found or not a valid integer
  * @see Resource.singleObjectStatement
  */
-fun Resource.extractIntegerValue(pred: Property): Int? =
-    try {
-        singleObjectStatement(pred)?.int
-    } catch (ex: Exception) {
-        LOGGER.debug("Failed to extract integer value for ${pred.uri} from $uri", ex)
-        null
-    }
+fun Resource.extractIntegerValue(pred: Property): Int? = try {
+    singleObjectStatement(pred)?.int
+} catch (ex: Exception) {
+    LOGGER.debug("Failed to extract integer value for ${pred.uri} from $uri", ex)
+    null
+}
 
 /**
  * Extension function to extract a single double value for a given predicate.
@@ -159,13 +154,12 @@ fun Resource.extractIntegerValue(pred: Property): Int? =
  * @return The double value, or null if not found or not a valid double
  * @see Resource.singleObjectStatement
  */
-fun Resource.extractDoubleValue(pred: Property): Double? =
-    try {
-        singleObjectStatement(pred)?.double
-    } catch (ex: Exception) {
-        LOGGER.debug("Failed to extract double value for ${pred.uri} from $uri", ex)
-        null
-    }
+fun Resource.extractDoubleValue(pred: Property): Double? = try {
+    singleObjectStatement(pred)?.double
+} catch (ex: Exception) {
+    LOGGER.debug("Failed to extract double value for ${pred.uri} from $uri", ex)
+    null
+}
 
 /**
  * Extension function to extract a list of string values for a given predicate.
@@ -176,12 +170,11 @@ fun Resource.extractDoubleValue(pred: Property): Double? =
  * @return List of string values, or null if no values found
  * @see Resource.listProperties
  */
-fun Resource.extractListOfStrings(pred: Property): List<String>? =
-    listProperties(pred)
-        .asSequence()
-        .mapNotNull { it.extractStringValue() }
-        .toList()
-        .ifEmpty { null }
+fun Resource.extractListOfStrings(pred: Property): List<String>? = listProperties(pred)
+    .asSequence()
+    .mapNotNull { it.extractStringValue() }
+    .toList()
+    .ifEmpty { null }
 
 /**
  * Extension function to extract a string value with its language tag.
@@ -215,11 +208,7 @@ fun Statement.extractStringLanguagePair(): Pair<LanguageCodes, String>? {
  * @param obj The URI object value
  * @return true if the triple exists, false otherwise
  */
-fun Model.containsTriple(
-    subj: String,
-    pred: String,
-    obj: URI,
-): Boolean {
+fun Model.containsTriple(subj: String, pred: String, obj: URI): Boolean {
     val askQuery = "ASK { <$subj> <$pred> <$obj> }"
 
     return try {
@@ -240,11 +229,7 @@ fun Model.containsTriple(
  * @param obj The string object value
  * @return true if the triple exists, false otherwise
  */
-fun Model.containsTriple(
-    subj: String,
-    pred: String,
-    obj: String,
-): Boolean {
+fun Model.containsTriple(subj: String, pred: String, obj: String): Boolean {
     val askQuery = "ASK { <$subj> <$pred> '$obj' }"
 
     return try {
@@ -263,11 +248,7 @@ fun Model.containsTriple(
  * @param obj The boolean object value
  * @return true if the triple exists, false otherwise
  */
-fun Model.containsTriple(
-    subj: String,
-    pred: String,
-    obj: Boolean,
-): Boolean {
+fun Model.containsTriple(subj: String, pred: String, obj: Boolean): Boolean {
     val askQuery = "ASK { <$subj> <$pred> $obj }"
 
     return try {
@@ -284,12 +265,11 @@ fun Model.containsTriple(
  * @param stmt The statement to check
  * @return true if the object is a URI resource, false otherwise
  */
-fun isURIResource(stmt: Statement): Boolean =
-    try {
-        stmt.resource?.isURIResource == true
-    } catch (ex: Exception) {
-        false
-    }
+fun isURIResource(stmt: Statement): Boolean = try {
+    stmt.resource?.isURIResource == true
+} catch (ex: Exception) {
+    false
+}
 
 /**
  * Checks if a statement's object is a resource (URI or blank node).
@@ -297,12 +277,11 @@ fun isURIResource(stmt: Statement): Boolean =
  * @param stmt The statement to check
  * @return true if the object is a resource, false otherwise
  */
-fun isResource(stmt: Statement): Boolean =
-    try {
-        stmt.resource?.isResource == true
-    } catch (ex: Exception) {
-        false
-    }
+fun isResource(stmt: Statement): Boolean = try {
+    stmt.resource?.isResource == true
+} catch (ex: Exception) {
+    false
+}
 
 /**
  * Checks if a URI is a product of skolemization.

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/LegalResource.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/LegalResource.kt
@@ -8,18 +8,17 @@ import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.RDFS
 import org.apache.jena.vocabulary.SKOS
 
-private fun LegalResource.hasContent() =
-    when {
-        uri != null -> true
-        title != null -> true
-        dctTitle != null -> true
-        description != null -> true
-        language != null -> true
-        type != null -> true
-        seeAlso != null -> true
-        relation != null -> true
-        else -> false
-    }
+private fun LegalResource.hasContent() = when {
+    uri != null -> true
+    title != null -> true
+    dctTitle != null -> true
+    description != null -> true
+    language != null -> true
+    type != null -> true
+    seeAlso != null -> true
+    relation != null -> true
+    else -> false
+}
 
 private fun Resource.buildLegalResource(): LegalResource? {
     val builder = LegalResource.newBuilder()
@@ -45,7 +44,6 @@ private fun Resource.buildLegalResource(): LegalResource? {
  * @param predicate the property predicate that points to the legal resource(s)
  * @return list of legal resources or `null` when no legal resource information exists
  */
-fun Resource.extractListOfLegalResources(predicate: Property): List<LegalResource>? =
-    listResources(predicate)
-        ?.mapNotNull { it.buildLegalResource() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfLegalResources(predicate: Property): List<LegalResource>? = listResources(predicate)
+    ?.mapNotNull { it.buildLegalResource() }
+    ?.takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/LocalizedStrings.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/LocalizedStrings.kt
@@ -5,14 +5,13 @@ import no.digdir.fdk.parserservice.model.LanguageCodes
 import org.apache.jena.rdf.model.Property
 import org.apache.jena.rdf.model.Resource
 
-fun LocalizedStrings.hasContent() =
-    when {
-        no != null -> true
-        nb != null -> true
-        nn != null -> true
-        en != null -> true
-        else -> false
-    }
+fun LocalizedStrings.hasContent() = when {
+    no != null -> true
+    nb != null -> true
+    nn != null -> true
+    en != null -> true
+    else -> false
+}
 
 /**
  * Extension function to extract localized strings from an RDF resource.
@@ -99,17 +98,16 @@ fun LocalizedStrings.descriptionHtmlCleaner(): LocalizedStrings {
  * @return List of LocalizedStrings objects, or null if no values found
  * @see Statement.extractStringLanguagePair
  */
-fun Resource.extractLocalizedStringList(pred: Property): List<LocalizedStrings>? =
-    listProperties(pred)
-        .asSequence()
-        .mapNotNull { it.extractStringLanguagePair() }
-        .map { pair ->
-            when (pair.first) {
-                LanguageCodes.NORWEGIAN -> LocalizedStrings().also { it.no = pair.second }
-                LanguageCodes.NORWEGIAN_BOKMAL -> LocalizedStrings().also { it.nb = pair.second }
-                LanguageCodes.NORWEGIAN_NYNORSK -> LocalizedStrings().also { it.nn = pair.second }
-                LanguageCodes.ENGLISH -> LocalizedStrings().also { it.en = pair.second }
-                LanguageCodes.NONE -> LocalizedStrings().also { it.no = pair.second }
-            }
-        }.toList()
-        .takeIf { it.isNotEmpty() }
+fun Resource.extractLocalizedStringList(pred: Property): List<LocalizedStrings>? = listProperties(pred)
+    .asSequence()
+    .mapNotNull { it.extractStringLanguagePair() }
+    .map { pair ->
+        when (pair.first) {
+            LanguageCodes.NORWEGIAN -> LocalizedStrings().also { it.no = pair.second }
+            LanguageCodes.NORWEGIAN_BOKMAL -> LocalizedStrings().also { it.nb = pair.second }
+            LanguageCodes.NORWEGIAN_NYNORSK -> LocalizedStrings().also { it.nn = pair.second }
+            LanguageCodes.ENGLISH -> LocalizedStrings().also { it.en = pair.second }
+            LanguageCodes.NONE -> LocalizedStrings().also { it.no = pair.second }
+        }
+    }.toList()
+    .takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/Organization.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/Organization.kt
@@ -12,17 +12,16 @@ import org.apache.jena.vocabulary.RDF
 import org.apache.jena.vocabulary.ROV
 import org.apache.jena.vocabulary.SKOS
 
-private fun Organization.hasContent() =
-    when {
-        uri != null -> true
-        id != null -> true
-        name != null -> true
-        orgPath != null -> true
-        organisasjonsform != null -> true
-        prefLabel != null -> true
-        title != null -> true
-        else -> false
-    }
+private fun Organization.hasContent() = when {
+    uri != null -> true
+    id != null -> true
+    name != null -> true
+    orgPath != null -> true
+    organisasjonsform != null -> true
+    prefLabel != null -> true
+    title != null -> true
+    else -> false
+}
 
 /**
  * Extension function to extract organization information from an RDF resource.
@@ -52,10 +51,9 @@ fun Resource.extractOrganization(pred: Property): Organization? {
  * @param pred The property predicate pointing to the organization resource
  * @return List of organization objects with extracted metadata, or null if no organizations found
  */
-fun Resource.extractListOfOrganizations(pred: Property): List<Organization>? =
-    listResources(pred)
-        ?.mapNotNull { it.buildOrganization() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfOrganizations(pred: Property): List<Organization>? = listResources(pred)
+    ?.mapNotNull { it.buildOrganization() }
+    ?.takeIf { it.isNotEmpty() }
 
 private fun Resource.buildOrganization(): Organization? {
     val builder = Organization.newBuilder()
@@ -117,7 +115,6 @@ private fun Resource.buildForGenericAgent(builder: Organization.Builder): Organi
  * @return The organizational form code, or null if not found
  * @see Resource.extractStringValue
  */
-private fun Resource.extractOrgForm(): String? =
-    extractStringValue(ROV.orgType)
-        ?.split("#")
-        ?.last()
+private fun Resource.extractOrgForm(): String? = extractStringValue(ROV.orgType)
+    ?.split("#")
+    ?.last()

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/ReferenceDataCode.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/ReferenceDataCode.kt
@@ -4,13 +4,12 @@ import no.digdir.fdk.model.ReferenceDataCode
 import org.apache.jena.rdf.model.Property
 import org.apache.jena.rdf.model.Resource
 
-private fun ReferenceDataCode.hasContent() =
-    when {
-        uri != null -> true
-        code != null -> true
-        prefLabel != null -> true
-        else -> false
-    }
+private fun ReferenceDataCode.hasContent() = when {
+    uri != null -> true
+    code != null -> true
+    prefLabel != null -> true
+    else -> false
+}
 
 /**
  * Builds ReferenceDataCode.
@@ -19,10 +18,7 @@ private fun ReferenceDataCode.hasContent() =
  * @param labelPredicate The predicate for the label value
  * @return ReferenceDataCode if able to find any values for the object, null otherwise
  */
-private fun Resource.buildReferenceDataCode(
-    codePredicate: Property,
-    labelPredicate: Property,
-): ReferenceDataCode? {
+private fun Resource.buildReferenceDataCode(codePredicate: Property, labelPredicate: Property): ReferenceDataCode? {
     val builder = ReferenceDataCode.newBuilder()
 
     builder
@@ -40,10 +36,7 @@ private fun Resource.buildReferenceDataCode(
  * @param labelPredicate The predicate for the label value
  * @return ReferenceDataCode if able to find any values for the object, null otherwise
  */
-private fun Resource.buildReferenceDataCode(
-    codeSeparator: String?,
-    labelPredicate: Property,
-): ReferenceDataCode? {
+private fun Resource.buildReferenceDataCode(codeSeparator: String?, labelPredicate: Property): ReferenceDataCode? {
     val builder = ReferenceDataCode.newBuilder()
     val uri = extractURIStringValue()
 
@@ -63,11 +56,7 @@ private fun Resource.buildReferenceDataCode(
  * @param labelPredicate The predicate for the label value
  * @return ReferenceDataCode if any exists, null otherwise
  */
-fun Resource.extractReferenceDataCode(
-    mainPredicate: Property,
-    codePredicate: Property,
-    labelPredicate: Property,
-): ReferenceDataCode? =
+fun Resource.extractReferenceDataCode(mainPredicate: Property, codePredicate: Property, labelPredicate: Property): ReferenceDataCode? =
     singleResource(mainPredicate)
         ?.buildReferenceDataCode(codePredicate, labelPredicate)
 
@@ -79,11 +68,7 @@ fun Resource.extractReferenceDataCode(
  * @param labelPredicate The predicate for the label value
  * @return ReferenceDataCode if any exists, null otherwise
  */
-fun Resource.extractReferenceDataCode(
-    mainPredicate: Property,
-    codeSeparator: String?,
-    labelPredicate: Property,
-): ReferenceDataCode? =
+fun Resource.extractReferenceDataCode(mainPredicate: Property, codeSeparator: String?, labelPredicate: Property): ReferenceDataCode? =
     singleResource(mainPredicate)
         ?.buildReferenceDataCode(codeSeparator, labelPredicate)
 
@@ -99,10 +84,9 @@ fun Resource.extractListOfReferenceDataCodes(
     mainPredicate: Property,
     codePredicate: Property,
     labelPredicate: Property,
-): List<ReferenceDataCode>? =
-    listResources(mainPredicate)
-        ?.mapNotNull { it.buildReferenceDataCode(codePredicate, labelPredicate) }
-        ?.takeIf { it.isNotEmpty() }
+): List<ReferenceDataCode>? = listResources(mainPredicate)
+    ?.mapNotNull { it.buildReferenceDataCode(codePredicate, labelPredicate) }
+    ?.takeIf { it.isNotEmpty() }
 
 /**
  * Extracts values for a list of resources originating from fdk-reference-data, missing a code predicate.
@@ -116,7 +100,6 @@ fun Resource.extractListOfReferenceDataCodes(
     mainPredicate: Property,
     codeSeparator: String?,
     labelPredicate: Property,
-): List<ReferenceDataCode>? =
-    listResources(mainPredicate)
-        ?.mapNotNull { it.buildReferenceDataCode(codeSeparator, labelPredicate) }
-        ?.takeIf { it.isNotEmpty() }
+): List<ReferenceDataCode>? = listResources(mainPredicate)
+    ?.mapNotNull { it.buildReferenceDataCode(codeSeparator, labelPredicate) }
+    ?.takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/RightsStatement.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/RightsStatement.kt
@@ -11,14 +11,12 @@ import org.apache.jena.vocabulary.SKOS
  *
  * @return populated `RightsStatement` or `null` when neither type nor description exists
  */
-fun Resource.extractRightsStatement(): RightsStatement? =
-    singleResource(DCTerms.rights)
-        ?.buildRightsStatement()
+fun Resource.extractRightsStatement(): RightsStatement? = singleResource(DCTerms.rights)
+    ?.buildRightsStatement()
 
-private fun Resource.buildRightsStatement(): RightsStatement? =
-    RightsStatement
-        .newBuilder()
-        .setType(extractReferenceDataCode(DCTerms.type, "/", SKOS.prefLabel))
-        .setDescription(extractLocalizedStrings(DCTerms.description))
-        .build()
-        .takeIf { it.type != null || it.description != null }
+private fun Resource.buildRightsStatement(): RightsStatement? = RightsStatement
+    .newBuilder()
+    .setType(extractReferenceDataCode(DCTerms.type, "/", SKOS.prefLabel))
+    .setDescription(extractLocalizedStrings(DCTerms.description))
+    .build()
+    .takeIf { it.type != null || it.description != null }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/Temporal.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/Temporal.kt
@@ -4,18 +4,14 @@ import no.digdir.fdk.model.Temporal
 import org.apache.jena.rdf.model.Property
 import org.apache.jena.rdf.model.Resource
 
-private fun Temporal.hasContent() =
-    when {
-        uri != null -> true
-        startDate != null -> true
-        endDate != null -> true
-        else -> false
-    }
+private fun Temporal.hasContent() = when {
+    uri != null -> true
+    startDate != null -> true
+    endDate != null -> true
+    else -> false
+}
 
-private fun Resource.buildTemporal(
-    startPredicate: Property,
-    endPredicate: Property,
-): Temporal? {
+private fun Resource.buildTemporal(startPredicate: Property, endPredicate: Property): Temporal? {
     val builder = Temporal.newBuilder()
 
     builder
@@ -35,11 +31,7 @@ private fun Resource.buildTemporal(
  * @param endPredicate predicate holding the end date literal
  * @return list of `Temporal` objects or `null` when none exist
  */
-fun Resource.extractListOfTemporal(
-    mainPredicate: Property,
-    startPredicate: Property,
-    endPredicate: Property,
-): List<Temporal>? =
+fun Resource.extractListOfTemporal(mainPredicate: Property, startPredicate: Property, endPredicate: Property): List<Temporal>? =
     listResources(mainPredicate)
         ?.mapNotNull { it.buildTemporal(startPredicate, endPredicate) }
         ?.takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/Theme.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/Theme.kt
@@ -16,13 +16,12 @@ private fun codeFromThemeURI(uri: String?): String? = uri?.split("/")?.last()
 
 fun isEuDataThemeURI(uri: String): Boolean = uri.contains(dataThemeBaseURL)
 
-private fun EuDataTheme.hasContent(): Boolean =
-    when {
-        uri != null -> true
-        code != null -> true
-        title != null -> true
-        else -> false
-    }
+private fun EuDataTheme.hasContent(): Boolean = when {
+    uri != null -> true
+    code != null -> true
+    title != null -> true
+    else -> false
+}
 
 /**
  * Extracts EU data theme metadata (code, URI and labels) from the resource.
@@ -46,14 +45,13 @@ fun Resource.extractEuDataTheme(): EuDataTheme? {
 
 fun isEurovocURI(uri: String): Boolean = uri.contains(eurovocBaseURL)
 
-private fun Eurovoc.hasContent(): Boolean =
-    when {
-        uri != null -> true
-        code != null -> true
-        label != null -> true
-        eurovocPaths != null -> true
-        else -> false
-    }
+private fun Eurovoc.hasContent(): Boolean = when {
+    uri != null -> true
+    code != null -> true
+    label != null -> true
+    eurovocPaths != null -> true
+    else -> false
+}
 
 /**
  * Extracts Eurovoc concept information including code, labels and stored theme paths.
@@ -78,14 +76,13 @@ fun Resource.extractEurovoc(): Eurovoc? {
 
 fun isLosURI(uri: String): Boolean = uri.contains(losBaseURL)
 
-private fun LosNode.hasContent(): Boolean =
-    when {
-        uri != null -> true
-        code != null -> true
-        name != null -> true
-        losPaths != null -> true
-        else -> false
-    }
+private fun LosNode.hasContent(): Boolean = when {
+    uri != null -> true
+    code != null -> true
+    name != null -> true
+    losPaths != null -> true
+    else -> false
+}
 
 /**
  * Extracts LOS theme metadata (code, labels, theme paths and tema flag) from the resource.

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/UriWithLabel.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/UriWithLabel.kt
@@ -14,21 +14,13 @@ import org.apache.jena.rdf.model.Statement
  * @param labelPred predicate used to extract the localized label
  * @return list of `UriWithLabel` objects or `null` when none exist
  */
-fun Resource.extractListOfUriWithLabel(
-    pred: Property,
-    uriPred: Property,
-    labelPred: Property,
-): List<UriWithLabel>? =
-    listProperties(pred)
-        .asSequence()
-        .mapNotNull { it.buildUriWithLabel(uriPred, labelPred) }
-        .toList()
-        .takeIf { it.isNotEmpty() }
+fun Resource.extractListOfUriWithLabel(pred: Property, uriPred: Property, labelPred: Property): List<UriWithLabel>? = listProperties(pred)
+    .asSequence()
+    .mapNotNull { it.buildUriWithLabel(uriPred, labelPred) }
+    .toList()
+    .takeIf { it.isNotEmpty() }
 
-private fun Statement.buildUriWithLabel(
-    uriPred: Property,
-    labelPred: Property,
-): UriWithLabel? {
+private fun Statement.buildUriWithLabel(uriPred: Property, labelPred: Property): UriWithLabel? {
     if (isResource(this)) {
         val builder = UriWithLabel.newBuilder()
         val uriValueFromPredicate = resource.extractStringValue(uriPred)
@@ -52,15 +44,11 @@ private fun Statement.buildUriWithLabel(
  * @param labelPred predicate supplying the localized label
  * @return list of `UriWithLabel` entries or `null` when no data is available
  */
-fun Resource.extractListOfUriWithLabel(
-    pred: Property,
-    labelPred: Property,
-): List<UriWithLabel>? =
-    listProperties(pred)
-        .asSequence()
-        .mapNotNull { it.buildUriWithLabel(labelPred) }
-        .toList()
-        .takeIf { it.isNotEmpty() }
+fun Resource.extractListOfUriWithLabel(pred: Property, labelPred: Property): List<UriWithLabel>? = listProperties(pred)
+    .asSequence()
+    .mapNotNull { it.buildUriWithLabel(labelPred) }
+    .toList()
+    .takeIf { it.isNotEmpty() }
 
 private fun Statement.buildUriWithLabel(labelPred: Property): UriWithLabel? {
     if (isResource(this)) {

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/UriWithLabelAndType.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/UriWithLabelAndType.kt
@@ -16,29 +16,21 @@ import org.apache.jena.vocabulary.SKOS
  * @param labelPred predicate providing a localized label
  * @return list of `UriWithLabelAndType` objects or `null` when no resources exist
  */
-fun Resource.extractListOfUriWithLabelAndType(
-    pred: Property,
-    uriPred: Property,
-    labelPred: Property,
-): List<UriWithLabelAndType>? =
+fun Resource.extractListOfUriWithLabelAndType(pred: Property, uriPred: Property, labelPred: Property): List<UriWithLabelAndType>? =
     listProperties(pred)
         .asSequence()
         .mapNotNull { it.buildUriWithLabelAndType(uriPred, labelPred) }
         .toList()
         .takeIf { it.isNotEmpty() }
 
-private fun Resource.extractNonConceptType(): String? =
-    listProperties(RDF.type)
-        .asSequence()
-        .filter { isResource(it) && it.resource != SKOS.Concept }
-        .firstOrNull()
-        ?.resource
-        ?.uri
+private fun Resource.extractNonConceptType(): String? = listProperties(RDF.type)
+    .asSequence()
+    .filter { isResource(it) && it.resource != SKOS.Concept }
+    .firstOrNull()
+    ?.resource
+    ?.uri
 
-private fun Statement.buildUriWithLabelAndType(
-    uriPred: Property,
-    labelPred: Property,
-): UriWithLabelAndType? {
+private fun Statement.buildUriWithLabelAndType(uriPred: Property, labelPred: Property): UriWithLabelAndType? {
     if (isResource(this)) {
         val builder = UriWithLabelAndType.newBuilder()
         val uriValueFromPredicate = resource.extractStringValue(uriPred)

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/concept/Collection.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/concept/Collection.kt
@@ -17,15 +17,14 @@ import java.net.URI
 
 private val LOGGER: Logger = LoggerFactory.getLogger("no.digdir.fdk.parserservice.extract.concept.Collection")
 
-private fun ConceptCollection.hasData(): Boolean =
-    when {
-        uri != null -> true
-        id != null -> true
-        label != null -> true
-        description != null -> true
-        publisher != null -> true
-        else -> false
-    }
+private fun ConceptCollection.hasData(): Boolean = when {
+    uri != null -> true
+    id != null -> true
+    label != null -> true
+    description != null -> true
+    publisher != null -> true
+    else -> false
+}
 
 /**
  * Extracts collection metadata for the concept.

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/concept/Definition.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/concept/Definition.kt
@@ -15,17 +15,16 @@ import org.apache.jena.vocabulary.RDF
 import org.apache.jena.vocabulary.RDFS
 import org.apache.jena.vocabulary.SKOS
 
-private fun Resource.extractSources(): List<UriWithText>? =
-    listResources(DCTerms.source)
-        ?.toList()
-        ?.map { source ->
-            UriWithText
-                .newBuilder()
-                .setUri(source.extractURIStringValue())
-                .setText(source.extractLocalizedStrings(RDFS.label))
-                .build()
-        }?.filter { it.uri != null || it.text != null }
-        ?.takeIf { it.isNotEmpty() }
+private fun Resource.extractSources(): List<UriWithText>? = listResources(DCTerms.source)
+    ?.toList()
+    ?.map { source ->
+        UriWithText
+            .newBuilder()
+            .setUri(source.extractURIStringValue())
+            .setText(source.extractLocalizedStrings(RDFS.label))
+            .build()
+    }?.filter { it.uri != null || it.text != null }
+    ?.takeIf { it.isNotEmpty() }
 
 private fun Resource.buildXlDefinition(): ConceptDefinition? {
     val builder = ConceptDefinition.newBuilder()
@@ -39,15 +38,13 @@ private fun Resource.buildXlDefinition(): ConceptDefinition? {
     return builder.build().takeIf { it.text != null }
 }
 
-private fun Resource.extractXlDefinitions(): List<ConceptDefinition> =
-    listResources(EUVOC.xlDefinition)
-        ?.mapNotNull { it.buildXlDefinition() }
-        ?: emptyList()
+private fun Resource.extractXlDefinitions(): List<ConceptDefinition> = listResources(EUVOC.xlDefinition)
+    ?.mapNotNull { it.buildXlDefinition() }
+    ?: emptyList()
 
-private fun Resource.extractDirectStatementDefinition(): List<ConceptDefinition> =
-    extractLocalizedStrings(SKOS.definition)
-        ?.let { listOf(ConceptDefinition().apply { text = it }) }
-        ?: emptyList()
+private fun Resource.extractDirectStatementDefinition(): List<ConceptDefinition> = extractLocalizedStrings(SKOS.definition)
+    ?.let { listOf(ConceptDefinition().apply { text = it }) }
+    ?: emptyList()
 
 /**
  * Extracts all definitions for a concept from the RDF resource.
@@ -75,17 +72,16 @@ fun Resource.extractDefinitions(): List<ConceptDefinition>? {
     }
 }
 
-private fun Resource.extractV1Sources(): List<UriWithText>? =
-    listResources(DCTerms.source)
-        ?.toList()
-        ?.map { source ->
-            UriWithText
-                .newBuilder()
-                .setUri(source.singleResource(RDFS.seeAlso)?.extractURIStringValue())
-                .setText(source.extractLocalizedStrings(RDFS.label))
-                .build()
-        }?.filter { it.uri != null || it.text != null }
-        ?.takeIf { it.isNotEmpty() }
+private fun Resource.extractV1Sources(): List<UriWithText>? = listResources(DCTerms.source)
+    ?.toList()
+    ?.map { source ->
+        UriWithText
+            .newBuilder()
+            .setUri(source.singleResource(RDFS.seeAlso)?.extractURIStringValue())
+            .setText(source.extractLocalizedStrings(RDFS.label))
+            .build()
+    }?.filter { it.uri != null || it.text != null }
+    ?.takeIf { it.isNotEmpty() }
 
 private fun Resource.extractV1TargetGroup(): String? {
     val value = extractStringValue(DCTerms.audience)
@@ -133,7 +129,6 @@ private fun Resource.buildV1Definition(): ConceptDefinition? {
  * @see SKOSNO.definisjon
  * @see extractDefinitions
  */
-fun Resource.extractDefinitionsV1(): List<ConceptDefinition>? =
-    listResources(SKOSNO.definisjon)
-        ?.mapNotNull { it.buildV1Definition() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractDefinitionsV1(): List<ConceptDefinition>? = listResources(SKOSNO.definisjon)
+    ?.mapNotNull { it.buildV1Definition() }
+    ?.takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/concept/Labels.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/concept/Labels.kt
@@ -18,9 +18,8 @@ import org.apache.jena.vocabulary.SKOSXL
  * @see SKOSXL.prefLabel
  * @see SKOSXL.literalForm
  */
-fun Resource.extractPrefLabelV1(): LocalizedStrings? =
-    singleResource(SKOSXL.prefLabel)
-        ?.extractLocalizedStrings(SKOSXL.literalForm)
+fun Resource.extractPrefLabelV1(): LocalizedStrings? = singleResource(SKOSXL.prefLabel)
+    ?.extractLocalizedStrings(SKOSXL.literalForm)
 
 /**
  * Extracts labels for a concept using SKOS-XL.
@@ -32,7 +31,6 @@ fun Resource.extractPrefLabelV1(): LocalizedStrings? =
  * @return A list of labels as `LocalizedStrings`, or `null` if no labels are found
  * @see SKOSXL.literalForm
  */
-fun Resource.extractLabelsV1(predicate: Property): List<LocalizedStrings>? =
-    listResources(predicate)
-        ?.mapNotNull { it.extractLocalizedStrings(SKOSXL.literalForm) }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractLabelsV1(predicate: Property): List<LocalizedStrings>? = listResources(predicate)
+    ?.mapNotNull { it.extractLocalizedStrings(SKOSXL.literalForm) }
+    ?.takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/concept/Subject.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/concept/Subject.kt
@@ -8,12 +8,11 @@ import org.apache.jena.rdf.model.Resource
 import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.SKOS
 
-private fun ConceptSubject.hasContent() =
-    when {
-        uri != null -> true
-        label != null -> true
-        else -> false
-    }
+private fun ConceptSubject.hasContent() = when {
+    uri != null -> true
+    label != null -> true
+    else -> false
+}
 
 private fun Resource.buildFromResource(): ConceptSubject? {
     val builder = ConceptSubject.newBuilder()

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/dataset/AccessService.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/dataset/AccessService.kt
@@ -10,14 +10,13 @@ import org.apache.jena.vocabulary.DCAT
 import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.SKOS
 
-private fun AccessService.hasContent() =
-    when {
-        uri != null -> true
-        title != null -> true
-        description != null -> true
-        endpointDescription != null -> true
-        else -> false
-    }
+private fun AccessService.hasContent() = when {
+    uri != null -> true
+    title != null -> true
+    description != null -> true
+    endpointDescription != null -> true
+    else -> false
+}
 
 private fun Resource.buildAccessService(): AccessService? {
     val builder = AccessService.newBuilder()
@@ -37,7 +36,6 @@ private fun Resource.buildAccessService(): AccessService? {
  *
  * @return list of `AccessService` objects or `null` when no services are declared
  */
-fun Resource.extractListOfAccessServices(): List<AccessService>? =
-    listResources(DCAT.accessService)
-        ?.mapNotNull { it.buildAccessService() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfAccessServices(): List<AccessService>? = listResources(DCAT.accessService)
+    ?.mapNotNull { it.buildAccessService() }
+    ?.takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/dataset/Distribution.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/dataset/Distribution.kt
@@ -23,22 +23,21 @@ import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.DC_11
 import org.apache.jena.vocabulary.SKOS
 
-private fun Distribution.hasContent() =
-    when {
-        uri != null -> true
-        title != null -> true
-        description != null -> true
-        accessURL != null -> true
-        downloadURL != null -> true
-        license != null -> true
-        conformsTo != null -> true
-        page != null -> true
-        fdkFormat != null -> true
-        compressFormat != null -> true
-        packageFormat != null -> true
-        accessService != null -> true
-        else -> false
-    }
+private fun Distribution.hasContent() = when {
+    uri != null -> true
+    title != null -> true
+    description != null -> true
+    accessURL != null -> true
+    downloadURL != null -> true
+    license != null -> true
+    conformsTo != null -> true
+    page != null -> true
+    fdkFormat != null -> true
+    compressFormat != null -> true
+    packageFormat != null -> true
+    accessService != null -> true
+    else -> false
+}
 
 private fun Resource.addCommonDistributionValuesToBuilder(builder: Distribution.Builder) {
     builder
@@ -168,10 +167,9 @@ private fun Resource.buildMobilitySampleData(): Distribution? {
  * @param mainPredicate predicate referencing distribution resources
  * @return list of distributions or `null` when no resources are available
  */
-fun Resource.extractListOfDistributionsV1(mainPredicate: Property): List<Distribution>? =
-    listResources(mainPredicate)
-        ?.mapNotNull { it.buildDistributionV1() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfDistributionsV1(mainPredicate: Property): List<Distribution>? = listResources(mainPredicate)
+    ?.mapNotNull { it.buildDistributionV1() }
+    ?.takeIf { it.isNotEmpty() }
 
 /**
  * Extracts distributions compliant with DCAT-AP-NO v2 by following the predicate.
@@ -179,10 +177,9 @@ fun Resource.extractListOfDistributionsV1(mainPredicate: Property): List<Distrib
  * @param mainPredicate predicate referencing distribution resources
  * @return list of distributions or `null` when no resources are available
  */
-fun Resource.extractListOfDistributionsV2(mainPredicate: Property): List<Distribution>? =
-    listResources(mainPredicate)
-        ?.mapNotNull { it.buildDistributionV2() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfDistributionsV2(mainPredicate: Property): List<Distribution>? = listResources(mainPredicate)
+    ?.mapNotNull { it.buildDistributionV2() }
+    ?.takeIf { it.isNotEmpty() }
 
 /**
  * Extracts distributions compliant with DCAT-AP-NO v3 by following the predicate.
@@ -190,27 +187,24 @@ fun Resource.extractListOfDistributionsV2(mainPredicate: Property): List<Distrib
  * @param mainPredicate predicate referencing distribution resources
  * @return list of distributions or `null` when no resources are available
  */
-fun Resource.extractListOfDistributionsV3(mainPredicate: Property): List<Distribution>? =
-    listResources(mainPredicate)
-        ?.mapNotNull { it.buildDistributionV3() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfDistributionsV3(mainPredicate: Property): List<Distribution>? = listResources(mainPredicate)
+    ?.mapNotNull { it.buildDistributionV3() }
+    ?.takeIf { it.isNotEmpty() }
 
 /**
  * Extracts mobility-specific distributions (DCAT mobility profile) from `dcat:distribution`.
  *
  * @return list of mobility distributions or `null` when none exist
  */
-fun Resource.extractListOfMobilityDistributions(): List<Distribution>? =
-    listResources(DCAT.distribution)
-        ?.mapNotNull { it.buildDistributionMobility() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfMobilityDistributions(): List<Distribution>? = listResources(DCAT.distribution)
+    ?.mapNotNull { it.buildDistributionMobility() }
+    ?.takeIf { it.isNotEmpty() }
 
 /**
  * Extracts mobility sample distributions (ADMS sample) and maps them to dataset distributions.
  *
  * @return list of sample distributions or `null` when no sample data is available
  */
-fun Resource.extractListOfMobilitySampleData(): List<Distribution>? =
-    listResources(DCAT.distribution)
-        ?.mapNotNull { it.buildMobilitySampleData() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfMobilitySampleData(): List<Distribution>? = listResources(DCAT.distribution)
+    ?.mapNotNull { it.buildMobilitySampleData() }
+    ?.takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/dataset/LegalBasis.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/dataset/LegalBasis.kt
@@ -20,14 +20,13 @@ import java.net.URI
  * @param rule CPSV rule predicate (e.g. `CPSV.ruleForDisclosure`)
  * @return list of legal basis descriptors or `null` when none exist
  */
-fun Resource.extractListOfLegalBasisV2(rule: Property): List<UriWithLabelAndType>? =
-    listProperties(CPSV.follows)
-        .asSequence()
-        .filter { isURIResource(it) }
-        .filter { model.containsTriple(it.resource.uri, DCTerms.type.uri, URI.create(rule.uri)) }
-        .mapNotNull { it.resource.buildLegalBasisV2(rule) }
-        .toList()
-        .takeIf { it.isNotEmpty() }
+fun Resource.extractListOfLegalBasisV2(rule: Property): List<UriWithLabelAndType>? = listProperties(CPSV.follows)
+    .asSequence()
+    .filter { isURIResource(it) }
+    .filter { model.containsTriple(it.resource.uri, DCTerms.type.uri, URI.create(rule.uri)) }
+    .mapNotNull { it.resource.buildLegalBasisV2(rule) }
+    .toList()
+    .takeIf { it.isNotEmpty() }
 
 private fun Resource.buildLegalBasisV2(rule: Property): UriWithLabelAndType? {
     val builder = UriWithLabelAndType.newBuilder()

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/dataset/QualifiedAttribution.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/dataset/QualifiedAttribution.kt
@@ -8,12 +8,11 @@ import no.digdir.fdk.parserservice.vocabulary.PROV
 import org.apache.jena.rdf.model.Resource
 import org.apache.jena.vocabulary.DCAT
 
-private fun QualifiedAttribution.hasContent() =
-    when {
-        role != null -> true
-        agent != null -> true
-        else -> false
-    }
+private fun QualifiedAttribution.hasContent() = when {
+    role != null -> true
+    agent != null -> true
+    else -> false
+}
 
 private fun Resource.buildQualifiedAttribution(): QualifiedAttribution? {
     val builder = QualifiedAttribution.newBuilder()
@@ -31,7 +30,6 @@ private fun Resource.buildQualifiedAttribution(): QualifiedAttribution? {
  *
  * @return list of `QualifiedAttribution` items or `null` when none exist
  */
-fun Resource.extractListOfQualifiedAttributions(): List<QualifiedAttribution>? =
-    listResources(PROV.qualifiedAttribution)
-        ?.mapNotNull { it.buildQualifiedAttribution() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfQualifiedAttributions(): List<QualifiedAttribution>? = listResources(PROV.qualifiedAttribution)
+    ?.mapNotNull { it.buildQualifiedAttribution() }
+    ?.takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/dataset/QualityAnnotation.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/dataset/QualityAnnotation.kt
@@ -84,10 +84,9 @@ private fun Resource.buildQualityAnnotation(): QualityAnnotation? {
  * @param dimension DQV dimension resource to filter on
  * @return matching `QualityAnnotation` or `null` when none is found
  */
-fun Resource.extractQualityAnnotationV2(dimension: Resource): QualityAnnotation? =
-    listResources(DQV.hasQualityAnnotation)
-        ?.firstOrNull { model.containsTriple(it.uri, DQV.inDimension.uri, URI.create(dimension.uri)) }
-        ?.buildQualityAnnotationV2(dimension)
+fun Resource.extractQualityAnnotationV2(dimension: Resource): QualityAnnotation? = listResources(DQV.hasQualityAnnotation)
+    ?.firstOrNull { model.containsTriple(it.uri, DQV.inDimension.uri, URI.create(dimension.uri)) }
+    ?.buildQualityAnnotationV2(dimension)
 
 /**
  * Extracts all quality annotations (DQV) associated with a dataset or distribution.
@@ -95,7 +94,6 @@ fun Resource.extractQualityAnnotationV2(dimension: Resource): QualityAnnotation?
  * @receiver the RDF resource of the dataset to extract quality annotations from
  * @return list of `QualityAnnotation` objects, or `null` if no annotations are found
  */
-fun Resource.extractListOfQualityAnnotations(): List<QualityAnnotation>? =
-    listResources(DQV.hasQualityAnnotation)
-        ?.mapNotNull { it.buildQualityAnnotation() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfQualityAnnotations(): List<QualityAnnotation>? = listResources(DQV.hasQualityAnnotation)
+    ?.mapNotNull { it.buildQualityAnnotation() }
+    ?.takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/dataset/References.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/dataset/References.kt
@@ -10,13 +10,12 @@ import org.apache.jena.rdf.model.Resource
 import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.RDFS
 
-private fun Reference.hasContent() =
-    when {
-        referenceType != null -> true
-        source?.uri != null -> true
-        source?.prefLabel != null -> true
-        else -> false
-    }
+private fun Reference.hasContent() = when {
+    referenceType != null -> true
+    source?.uri != null -> true
+    source?.prefLabel != null -> true
+    else -> false
+}
 
 private fun Resource.buildReference(predicate: Property): Reference? {
     val codeBuilder = ReferenceDataCode.newBuilder()

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/dataset/Subject.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/dataset/Subject.kt
@@ -9,14 +9,13 @@ import org.apache.jena.rdf.model.Resource
 import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.SKOS
 
-private fun Subject.hasContent() =
-    when {
-        uri != null -> true
-        identifier != null -> true
-        prefLabel != null -> true
-        definition != null -> true
-        else -> false
-    }
+private fun Subject.hasContent() = when {
+    uri != null -> true
+    identifier != null -> true
+    prefLabel != null -> true
+    definition != null -> true
+    else -> false
+}
 
 private fun Resource.buildSubject(): Subject? {
     val builder = Subject.newBuilder()
@@ -36,7 +35,6 @@ private fun Resource.buildSubject(): Subject? {
  *
  * @return list of dataset subjects or `null` when none are declared
  */
-fun Resource.extractListOfSubjects(): List<Subject>? =
-    listResources(DCTerms.subject)
-        ?.mapNotNull { it.buildSubject() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfSubjects(): List<Subject>? = listResources(DCTerms.subject)
+    ?.mapNotNull { it.buildSubject() }
+    ?.takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/fdk/BuilderExtensions.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/fdk/BuilderExtensions.kt
@@ -15,10 +15,7 @@ import org.apache.jena.rdf.model.Resource
  * @param recordResource The jena resource of the fdkRecord
  * @param datasetResource The jena resource of the dataset
  */
-fun Dataset.Builder.addFdkData(
-    recordResource: Resource,
-    datasetResource: Resource,
-) {
+fun Dataset.Builder.addFdkData(recordResource: Resource, datasetResource: Resource) {
     setId(fdkIdFromRecord(recordResource))
     setHarvest(harvestMetaData(recordResource))
 

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/fdk/HarvestData.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/fdk/HarvestData.kt
@@ -30,10 +30,7 @@ import java.net.URI
  * @see Model.listResourcesWithProperty
  * @see isValidFDKRecord
  */
-fun fdkRecord(
-    resource: Resource,
-    fdkId: String,
-): Resource {
+fun fdkRecord(resource: Resource, fdkId: String): Resource {
     val records =
         resource.model
             .listResourcesWithProperty(FOAF.primaryTopic, resource)
@@ -64,17 +61,13 @@ fun fdkIdFromRecord(recordResource: Resource): String? = recordResource.singleOb
  * @param model The Jena RDF model containing the graph
  * @return The IRI of the primary topic in the record
  */
-fun topicUriOfRecordWithID(
-    id: String,
-    model: Model,
-): String? =
-    model
-        .listSubjectsWithProperty(DCTerms.identifier, id)
-        .asSequence()
-        .filter { it.isURIResource }
-        .firstOrNull()
-        ?.getPropertyResourceValue(FOAF.primaryTopic)
-        ?.uri
+fun topicUriOfRecordWithID(id: String, model: Model): String? = model
+    .listSubjectsWithProperty(DCTerms.identifier, id)
+    .asSequence()
+    .filter { it.isURIResource }
+    .firstOrNull()
+    ?.getPropertyResourceValue(FOAF.primaryTopic)
+    ?.uri
 
 /**
  * Extracts a resource by an identifying URI.
@@ -85,14 +78,10 @@ fun topicUriOfRecordWithID(
  * @throws Exception if no resource is found
  * @see Model.getResource
  */
-fun resourceOfIRI(
-    model: Model,
-    iri: String,
-): Resource =
-    model
-        .getResource(iri)
-        ?.takeIf { it.isURIResource }
-        ?: throw NoResourceFoundException("No resource found with uri $iri")
+fun resourceOfIRI(model: Model, iri: String): Resource = model
+    .getResource(iri)
+    ?.takeIf { it.isURIResource }
+    ?: throw NoResourceFoundException("No resource found with uri $iri")
 
 /**
  * Determines if a CatalogRecord follows the pattern of FDK harvest records.
@@ -107,30 +96,26 @@ fun resourceOfIRI(
  * @param fdkId The relevant FDK ID
  * @return true if the record is a valid FDK record, false otherwise
  */
-private fun isValidFDKRecord(
-    recordResource: Resource,
-    fdkId: String,
-): Boolean =
-    when {
-        // All FDK records are URI resources.
-        !recordResource.isURIResource -> false
+private fun isValidFDKRecord(recordResource: Resource, fdkId: String): Boolean = when {
+    // All FDK records are URI resources.
+    !recordResource.isURIResource -> false
 
-        // Checks that the record has the correct identifier value.
-        !recordResource.model.containsTriple(
-            recordResource.uri,
-            DCTerms.identifier.uri,
-            fdkId,
-        ) -> false
+    // Checks that the record has the correct identifier value.
+    !recordResource.model.containsTriple(
+        recordResource.uri,
+        DCTerms.identifier.uri,
+        fdkId,
+    ) -> false
 
-        // All FDK records has type dcat:CatalogRecord.
-        !recordResource.model.containsTriple(
-            recordResource.uri,
-            RDF.type.uri,
-            URI.create(DCAT.CatalogRecord.uri),
-        ) -> false
+    // All FDK records has type dcat:CatalogRecord.
+    !recordResource.model.containsTriple(
+        recordResource.uri,
+        RDF.type.uri,
+        URI.create(DCAT.CatalogRecord.uri),
+    ) -> false
 
-        else -> true
-    }
+    else -> true
+}
 
 /**
  * Constructs HarvestMetaData from FDK harvest metadata.

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/informationmodel/ModelElement.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/informationmodel/ModelElement.kt
@@ -18,50 +18,48 @@ import org.apache.jena.vocabulary.RDF
 import org.apache.jena.vocabulary.SKOS
 import org.apache.jena.vocabulary.XSD
 
-private fun InformationModelElement.hasContent() =
-    when {
-        uri != null -> true
-        identifier != null -> true
-        title != null -> true
-        description != null -> true
-        subject != null -> true
-        hasProperty != null -> true
-        belongsToModule != null -> true
-        elementTypes != null -> true
-        codeListReference != null -> true
-        codes != null -> true
-        typeDefinitionReference != null -> true
-        fractionDigits != null -> true
-        length != null -> true
-        maxInclusive != null -> true
-        maxLength != null -> true
-        minInclusive != null -> true
-        minLength != null -> true
-        pattern != null -> true
-        totalDigits != null -> true
-        else -> false
-    }
+private fun InformationModelElement.hasContent() = when {
+    uri != null -> true
+    identifier != null -> true
+    title != null -> true
+    description != null -> true
+    subject != null -> true
+    hasProperty != null -> true
+    belongsToModule != null -> true
+    elementTypes != null -> true
+    codeListReference != null -> true
+    codes != null -> true
+    typeDefinitionReference != null -> true
+    fractionDigits != null -> true
+    length != null -> true
+    maxInclusive != null -> true
+    maxLength != null -> true
+    minInclusive != null -> true
+    minLength != null -> true
+    pattern != null -> true
+    totalDigits != null -> true
+    else -> false
+}
 
-private fun InformationModelCodeElement.hasContent() =
-    when {
-        uri != null -> true
-        identifier != null -> true
-        prefLabel != null -> true
-        subject != null -> true
-        notation != null -> true
-        topConceptOf != null -> true
-        definition != null -> true
-        example != null -> true
-        exclusionNote != null -> true
-        previousElement != null -> true
-        hiddenLabel != null -> true
-        inclusionNote != null -> true
-        note != null -> true
-        nextElement != null -> true
-        scopeNote != null -> true
-        altLabel != null -> true
-        else -> false
-    }
+private fun InformationModelCodeElement.hasContent() = when {
+    uri != null -> true
+    identifier != null -> true
+    prefLabel != null -> true
+    subject != null -> true
+    notation != null -> true
+    topConceptOf != null -> true
+    definition != null -> true
+    example != null -> true
+    exclusionNote != null -> true
+    previousElement != null -> true
+    hiddenLabel != null -> true
+    inclusionNote != null -> true
+    note != null -> true
+    nextElement != null -> true
+    scopeNote != null -> true
+    altLabel != null -> true
+    else -> false
+}
 
 private fun Resource.buildModelCodeElement(): InformationModelCodeElement? {
     val builder = InformationModelCodeElement.newBuilder()

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/informationmodel/ModelFormat.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/informationmodel/ModelFormat.kt
@@ -13,15 +13,14 @@ import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.RDFS
 import org.apache.jena.vocabulary.SKOS
 
-private fun InformationModelFormat.hasContent(): Boolean =
-    when {
-        uri != null -> true
-        title != null -> true
-        seeAlso != null -> true
-        format != null -> true
-        language != null -> true
-        else -> false
-    }
+private fun InformationModelFormat.hasContent(): Boolean = when {
+    uri != null -> true
+    title != null -> true
+    seeAlso != null -> true
+    format != null -> true
+    language != null -> true
+    else -> false
+}
 
 /**
  * Extracts `dct:hasFormat` resources and converts them into `InformationModelFormat`
@@ -29,12 +28,11 @@ private fun InformationModelFormat.hasContent(): Boolean =
  *
  * @return list of model formats or `null` when the information model declares none
  */
-fun Resource.extractListOfModelFormat(): List<InformationModelFormat>? =
-    listProperties(DCTerms.hasFormat)
-        .asSequence()
-        .mapNotNull { it.buildModelFormat() }
-        .toList()
-        .takeIf { it.isNotEmpty() }
+fun Resource.extractListOfModelFormat(): List<InformationModelFormat>? = listProperties(DCTerms.hasFormat)
+    .asSequence()
+    .mapNotNull { it.buildModelFormat() }
+    .toList()
+    .takeIf { it.isNotEmpty() }
 
 private fun Statement.buildModelFormat(): InformationModelFormat? {
     if (isResource(this)) {

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/informationmodel/ModelProperty.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/informationmodel/ModelProperty.kt
@@ -13,35 +13,34 @@ import org.apache.jena.rdf.model.Resource
 import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.RDF
 
-private fun InformationModelProperty.hasContent() =
-    when {
-        uri != null -> true
-        identifier != null -> true
-        title != null -> true
-        description != null -> true
-        subject != null -> true
-        propertyTypes != null -> true
-        minOccurs != null -> true
-        maxOccurs != null -> true
-        hasType != null -> true
-        relationPropertyLabel != null -> true
-        sequenceNumber != null -> true
-        belongsToModule != null -> true
-        formsSymmetryWith != null -> true
-        isAbstractionOf != null -> true
-        refersTo != null -> true
-        hasDataType != null -> true
-        hasSimpleType != null -> true
-        hasObjectType != null -> true
-        hasValueFrom != null -> true
-        hasSome != null -> true
-        hasMember != null -> true
-        contains != null -> true
-        hasSupplier != null -> true
-        hasGeneralConcept != null -> true
-        notification != null -> true
-        else -> false
-    }
+private fun InformationModelProperty.hasContent() = when {
+    uri != null -> true
+    identifier != null -> true
+    title != null -> true
+    description != null -> true
+    subject != null -> true
+    propertyTypes != null -> true
+    minOccurs != null -> true
+    maxOccurs != null -> true
+    hasType != null -> true
+    relationPropertyLabel != null -> true
+    sequenceNumber != null -> true
+    belongsToModule != null -> true
+    formsSymmetryWith != null -> true
+    isAbstractionOf != null -> true
+    refersTo != null -> true
+    hasDataType != null -> true
+    hasSimpleType != null -> true
+    hasObjectType != null -> true
+    hasValueFrom != null -> true
+    hasSome != null -> true
+    hasMember != null -> true
+    contains != null -> true
+    hasSupplier != null -> true
+    hasGeneralConcept != null -> true
+    notification != null -> true
+    else -> false
+}
 
 fun Resource.buildModelProperty(): InformationModelProperty? {
     val builder = InformationModelProperty.newBuilder()

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/informationmodel/ModelStandard.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/informationmodel/ModelStandard.kt
@@ -13,14 +13,13 @@ import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.OWL
 import org.apache.jena.vocabulary.RDFS
 
-private fun InformationModelStandard.hasContent(): Boolean =
-    when {
-        uri != null -> true
-        title != null -> true
-        seeAlso != null -> true
-        versionInfo != null -> true
-        else -> false
-    }
+private fun InformationModelStandard.hasContent(): Boolean = when {
+    uri != null -> true
+    title != null -> true
+    seeAlso != null -> true
+    versionInfo != null -> true
+    else -> false
+}
 
 /**
  * Extracts references to modelling standards/profiles and maps them to
@@ -29,12 +28,11 @@ private fun InformationModelStandard.hasContent(): Boolean =
  * @param pred predicate (e.g. `prof:isProfileOf`) pointing to the standard resource
  * @return list of standards or `null` when no references exist
  */
-fun Resource.extractListOfModelStandard(pred: Property): List<InformationModelStandard>? =
-    listProperties(pred)
-        .asSequence()
-        .mapNotNull { it.buildModelStandard() }
-        .toList()
-        .takeIf { it.isNotEmpty() }
+fun Resource.extractListOfModelStandard(pred: Property): List<InformationModelStandard>? = listProperties(pred)
+    .asSequence()
+    .mapNotNull { it.buildModelStandard() }
+    .toList()
+    .takeIf { it.isNotEmpty() }
 
 private fun Statement.buildModelStandard(): InformationModelStandard? {
     if (isResource(this)) {

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/service/Channel.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/service/Channel.kt
@@ -16,19 +16,18 @@ import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.SKOS
 import org.apache.jena.vocabulary.VCARD4
 
-private fun ServiceChannel.hasContent() =
-    when {
-        uri != null -> true
-        identifier != null -> true
-        channelType != null -> true
-        description != null -> true
-        processingTime != null -> true
-        hasInput != null -> true
-        email != null -> true
-        url != null -> true
-        telephone != null -> true
-        else -> false
-    }
+private fun ServiceChannel.hasContent() = when {
+    uri != null -> true
+    identifier != null -> true
+    channelType != null -> true
+    description != null -> true
+    processingTime != null -> true
+    hasInput != null -> true
+    email != null -> true
+    url != null -> true
+    telephone != null -> true
+    else -> false
+}
 
 private fun Resource.buildServiceChannel(hasInputPredicate: Property): ServiceChannel? {
     val builder = ServiceChannel.newBuilder()
@@ -54,10 +53,9 @@ private fun Resource.buildServiceChannel(hasInputPredicate: Property): ServiceCh
  *
  * @return list of service channels or `null` when no channel information exists
  */
-fun Resource.extractListOfServiceChannelsV0(): List<ServiceChannel>? =
-    listResources(CV.hasChannel)
-        ?.mapNotNull { it.buildServiceChannel(CPSV.hasInput) }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfServiceChannelsV0(): List<ServiceChannel>? = listResources(CV.hasChannel)
+    ?.mapNotNull { it.buildServiceChannel(CPSV.hasInput) }
+    ?.takeIf { it.isNotEmpty() }
 
 /**
  * Extracts all V1 service channel resources and converts them to `ServiceChannel`
@@ -66,7 +64,6 @@ fun Resource.extractListOfServiceChannelsV0(): List<ServiceChannel>? =
  *
  * @return list of service channels or `null` when no channel information exists
  */
-fun Resource.extractListOfServiceChannelsV1(): List<ServiceChannel>? =
-    listResources(CV.hasChannel)
-        ?.mapNotNull { it.buildServiceChannel(CPSVNO.hasRequiredEvidence) }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfServiceChannelsV1(): List<ServiceChannel>? = listResources(CV.hasChannel)
+    ?.mapNotNull { it.buildServiceChannel(CPSVNO.hasRequiredEvidence) }
+    ?.takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/service/ContactPoint.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/service/ContactPoint.kt
@@ -12,28 +12,25 @@ import org.apache.jena.rdf.model.Resource
 import org.apache.jena.vocabulary.SKOS
 import org.apache.jena.vocabulary.VCARD4
 
-private fun ServiceContactPoint.hasContent() =
-    when {
-        uri != null -> true
-        contactType != null -> true
-        email != null -> true
-        telephone != null -> true
-        contactPage != null -> true
-        language != null -> true
-        else -> false
-    }
+private fun ServiceContactPoint.hasContent() = when {
+    uri != null -> true
+    contactType != null -> true
+    email != null -> true
+    telephone != null -> true
+    contactPage != null -> true
+    language != null -> true
+    else -> false
+}
 
-private fun Resource.extractTelephone(): List<String>? =
-    extractListOfStrings(CV.telephone)
-        ?.map { it.removePrefix("tel:") }
-        ?.filter { it.isNotBlank() }
-        ?.takeIf { it.isNotEmpty() }
+private fun Resource.extractTelephone(): List<String>? = extractListOfStrings(CV.telephone)
+    ?.map { it.removePrefix("tel:") }
+    ?.filter { it.isNotBlank() }
+    ?.takeIf { it.isNotEmpty() }
 
-private fun Resource.extractEmail(): List<String>? =
-    extractListOfStrings(CV.email)
-        ?.map { it.removePrefix("mailto:") }
-        ?.filter { it.isNotBlank() }
-        ?.takeIf { it.isNotEmpty() }
+private fun Resource.extractEmail(): List<String>? = extractListOfStrings(CV.email)
+    ?.map { it.removePrefix("mailto:") }
+    ?.filter { it.isNotBlank() }
+    ?.takeIf { it.isNotEmpty() }
 
 private fun Resource.buildServiceContactPoint(): ServiceContactPoint? {
     val builder = ServiceContactPoint.newBuilder()
@@ -55,7 +52,6 @@ private fun Resource.buildServiceContactPoint(): ServiceContactPoint? {
  *
  * @return list of contact points or `null` when no contact point information exists
  */
-fun Resource.extractListOfServiceContactPoints(): List<ServiceContactPoint>? =
-    listResources(CV.contactPoint)
-        ?.mapNotNull { it.buildServiceContactPoint() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfServiceContactPoints(): List<ServiceContactPoint>? = listResources(CV.contactPoint)
+    ?.mapNotNull { it.buildServiceContactPoint() }
+    ?.takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/service/Evidence.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/service/Evidence.kt
@@ -18,18 +18,17 @@ import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.RDF
 import org.apache.jena.vocabulary.SKOS
 
-private fun ServiceEvidence.hasContent() =
-    when {
-        uri != null -> true
-        identifier != null -> true
-        rdfType != null -> true
-        dctType != null -> true
-        name != null -> true
-        description != null -> true
-        language != null -> true
-        page != null -> true
-        else -> false
-    }
+private fun ServiceEvidence.hasContent() = when {
+    uri != null -> true
+    identifier != null -> true
+    rdfType != null -> true
+    dctType != null -> true
+    name != null -> true
+    description != null -> true
+    language != null -> true
+    page != null -> true
+    else -> false
+}
 
 private fun Resource.extractEvidenceRdfType(): String? {
     val types = extractListOfStrings(RDF.type)

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/service/Output.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/service/Output.kt
@@ -13,17 +13,16 @@ import org.apache.jena.rdf.model.Resource
 import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.SKOS
 
-private fun ServiceOutput.hasContent() =
-    when {
-        uri != null -> true
-        identifier != null -> true
-        name != null -> true
-        description != null -> true
-        language != null -> true
-        type != null -> true
-        isPartOf != null -> true
-        else -> false
-    }
+private fun ServiceOutput.hasContent() = when {
+    uri != null -> true
+    identifier != null -> true
+    name != null -> true
+    description != null -> true
+    language != null -> true
+    type != null -> true
+    isPartOf != null -> true
+    else -> false
+}
 
 private fun Resource.buildServiceOutput(): ServiceOutput? {
     val builder = ServiceOutput.newBuilder()
@@ -47,7 +46,6 @@ private fun Resource.buildServiceOutput(): ServiceOutput? {
  * @param predicate the property predicate that points to the output resource(s)
  * @return list of service outputs or `null` when no output information exists
  */
-fun Resource.extractListOfServiceOutput(predicate: Property): List<ServiceOutput>? =
-    listResources(predicate)
-        ?.mapNotNull { it.buildServiceOutput() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfServiceOutput(predicate: Property): List<ServiceOutput>? = listResources(predicate)
+    ?.mapNotNull { it.buildServiceOutput() }
+    ?.takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/service/ParticipatingAgent.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/service/ParticipatingAgent.kt
@@ -12,15 +12,14 @@ import org.apache.jena.rdf.model.Resource
 import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.SKOS
 
-private fun ServiceParticipation.hasContent() =
-    when {
-        uri != null -> true
-        identifier != null -> true
-        description != null -> true
-        role != null -> true
-        agent != null -> true
-        else -> false
-    }
+private fun ServiceParticipation.hasContent() = when {
+    uri != null -> true
+    identifier != null -> true
+    description != null -> true
+    role != null -> true
+    agent != null -> true
+    else -> false
+}
 
 private fun Resource.buildServiceParticipation(): ServiceParticipation? {
     val builder = ServiceParticipation.newBuilder()
@@ -35,14 +34,13 @@ private fun Resource.buildServiceParticipation(): ServiceParticipation? {
     return builder.build().takeIf { it.hasContent() }
 }
 
-private fun ServiceAgent.hasContent() =
-    when {
-        uri != null -> true
-        identifier != null -> true
-        name != null -> true
-        playsRole != null -> true
-        else -> false
-    }
+private fun ServiceAgent.hasContent() = when {
+    uri != null -> true
+    identifier != null -> true
+    name != null -> true
+    playsRole != null -> true
+    else -> false
+}
 
 private fun Resource.buildServiceAgent(participation: List<ServiceParticipation>?): ServiceAgent? {
     val builder = ServiceAgent.newBuilder()

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/service/Requirement.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/service/Requirement.kt
@@ -12,16 +12,15 @@ import org.apache.jena.rdf.model.Resource
 import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.SKOS
 
-private fun ServiceRequirement.hasContent() =
-    when {
-        uri != null -> true
-        identifier != null -> true
-        dctTitle != null -> true
-        dctType != null -> true
-        description != null -> true
-        fulfils != null -> true
-        else -> false
-    }
+private fun ServiceRequirement.hasContent() = when {
+    uri != null -> true
+    identifier != null -> true
+    dctTitle != null -> true
+    dctType != null -> true
+    description != null -> true
+    fulfils != null -> true
+    else -> false
+}
 
 private fun Resource.buildServiceRequirement(): ServiceRequirement? {
     val builder = ServiceRequirement.newBuilder()
@@ -44,7 +43,6 @@ private fun Resource.buildServiceRequirement(): ServiceRequirement? {
  *
  * @return list of service requirements or `null` when no requirement information exists
  */
-fun Resource.extractListOfServiceRequirements(): List<ServiceRequirement>? =
-    listResources(CV.holdsRequirement)
-        ?.mapNotNull { it.buildServiceRequirement() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfServiceRequirements(): List<ServiceRequirement>? = listResources(CV.holdsRequirement)
+    ?.mapNotNull { it.buildServiceRequirement() }
+    ?.takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/extract/service/Rule.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/extract/service/Rule.kt
@@ -13,16 +13,15 @@ import org.apache.jena.rdf.model.Resource
 import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.SKOS
 
-private fun ServiceRule.hasContent() =
-    when {
-        uri != null -> true
-        identifier != null -> true
-        name != null -> true
-        description != null -> true
-        language != null -> true
-        legalResources != null -> true
-        else -> false
-    }
+private fun ServiceRule.hasContent() = when {
+    uri != null -> true
+    identifier != null -> true
+    name != null -> true
+    description != null -> true
+    language != null -> true
+    legalResources != null -> true
+    else -> false
+}
 
 private fun Resource.buildServiceRule(): ServiceRule? {
     val builder = ServiceRule.newBuilder()
@@ -45,7 +44,6 @@ private fun Resource.buildServiceRule(): ServiceRule? {
  *
  * @return list of service rules or `null` when no rule information exists
  */
-fun Resource.extractListOfServiceRules(): List<ServiceRule>? =
-    listResources(CPSV.follows)
-        ?.mapNotNull { it.buildServiceRule() }
-        ?.takeIf { it.isNotEmpty() }
+fun Resource.extractListOfServiceRules(): List<ServiceRule>? = listResources(CPSV.follows)
+    ?.mapNotNull { it.buildServiceRule() }
+    ?.takeIf { it.isNotEmpty() }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/handler/ConceptHandler.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/handler/ConceptHandler.kt
@@ -22,9 +22,7 @@ import tools.jackson.databind.JsonNode
  * @since 1.0.0
  */
 @Service
-class ConceptHandler(
-    private val parserRegistry: ConceptParserRegistry,
-) {
+class ConceptHandler(private val parserRegistry: ConceptParserRegistry) {
     /**
      * Parses a concept from RDF graph data and returns it as JSON.
      *
@@ -41,11 +39,7 @@ class ConceptHandler(
      * @throws NoAcceptableFDKRecordsException if no concept is found with the given identifier
      * @throws IllegalStateException if no parsers can successfully parse the concept
      */
-    fun parseConcept(
-        fdkId: String,
-        graph: String,
-        catalogGraph: String?,
-    ): JsonNode {
+    fun parseConcept(fdkId: String, graph: String, catalogGraph: String?): JsonNode {
         val model = ModelFactory.createDefaultModel()
         val concept: Concept =
             try {

--- a/src/main/kotlin/no/digdir/fdk/parserservice/handler/DataServiceHandler.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/handler/DataServiceHandler.kt
@@ -21,9 +21,7 @@ import tools.jackson.databind.JsonNode
  * @since 1.0.0
  */
 @Service
-class DataServiceHandler(
-    private val parserRegistry: DataServiceParserRegistry,
-) {
+class DataServiceHandler(private val parserRegistry: DataServiceParserRegistry) {
     /**
      * Parses a data service from RDF graph data and returns it as JSON.
      *
@@ -40,11 +38,7 @@ class DataServiceHandler(
      * @throws NoAcceptableFDKRecordsException if no data service is found with the given identifier
      * @throws IllegalStateException if no parsers can successfully parse the data service
      */
-    fun parseDataService(
-        fdkId: String,
-        graph: String,
-        catalogGraph: String?,
-    ): JsonNode {
+    fun parseDataService(fdkId: String, graph: String, catalogGraph: String?): JsonNode {
         val model = ModelFactory.createDefaultModel()
         val dataService: DataService =
             try {

--- a/src/main/kotlin/no/digdir/fdk/parserservice/handler/DatasetHandler.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/handler/DatasetHandler.kt
@@ -12,9 +12,7 @@ import org.springframework.stereotype.Service
 import tools.jackson.databind.JsonNode
 
 @Service
-class DatasetHandler(
-    private val parserRegistry: DatasetParserRegistry,
-) {
+class DatasetHandler(private val parserRegistry: DatasetParserRegistry) {
     /**
      * Parses a dataset from RDF graph data and returns it as JSON.
      *
@@ -31,11 +29,7 @@ class DatasetHandler(
      * @throws NoAcceptableFDKRecordsException if no dataset is found with the given identifier
      * @throws IllegalStateException if no parsers can successfully parse the dataset
      */
-    fun parseDataset(
-        fdkId: String,
-        graph: String,
-        catalogGraph: String?,
-    ): JsonNode {
+    fun parseDataset(fdkId: String, graph: String, catalogGraph: String?): JsonNode {
         val model = ModelFactory.createDefaultModel()
         val dataset: Dataset =
             try {

--- a/src/main/kotlin/no/digdir/fdk/parserservice/handler/EventHandler.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/handler/EventHandler.kt
@@ -21,9 +21,7 @@ import tools.jackson.databind.JsonNode
  * @since 1.0.0
  */
 @Service
-class EventHandler(
-    private val parserRegistry: EventParserRegistry,
-) {
+class EventHandler(private val parserRegistry: EventParserRegistry) {
     /**
      * Parses an event from RDF graph data and returns it as JSON.
      *
@@ -40,11 +38,7 @@ class EventHandler(
      * @throws NoAcceptableFDKRecordsException if no event is found with the given identifier
      * @throws IllegalStateException if no parsers can successfully parse the event
      */
-    fun parseEvent(
-        fdkId: String,
-        graph: String,
-        catalogGraph: String?,
-    ): JsonNode {
+    fun parseEvent(fdkId: String, graph: String, catalogGraph: String?): JsonNode {
         val model = ModelFactory.createDefaultModel()
         val event: no.digdir.fdk.model.event.Event =
             try {

--- a/src/main/kotlin/no/digdir/fdk/parserservice/handler/InformationModelHandler.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/handler/InformationModelHandler.kt
@@ -11,9 +11,7 @@ import org.springframework.stereotype.Service
 import tools.jackson.databind.JsonNode
 
 @Service
-class InformationModelHandler(
-    private val parserRegistry: InformationModelParserRegistry,
-) {
+class InformationModelHandler(private val parserRegistry: InformationModelParserRegistry) {
     /**
      * Parses an information model from RDF graph data and returns it as JSON.
      *
@@ -30,11 +28,7 @@ class InformationModelHandler(
      * @throws NoAcceptableFDKRecordsException if no information model is found with the given identifier
      * @throws IllegalStateException if no parsers can successfully parse the information model
      */
-    fun parseInformationModel(
-        fdkId: String,
-        graph: String,
-        catalogGraph: String?,
-    ): JsonNode {
+    fun parseInformationModel(fdkId: String, graph: String, catalogGraph: String?): JsonNode {
         val model = ModelFactory.createDefaultModel()
         val informationModel: InformationModel =
             try {

--- a/src/main/kotlin/no/digdir/fdk/parserservice/handler/ServiceHandler.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/handler/ServiceHandler.kt
@@ -21,9 +21,7 @@ import tools.jackson.databind.JsonNode
  * @since 1.0.0
  */
 @Service
-class ServiceHandler(
-    private val parserRegistry: ServiceParserRegistry,
-) {
+class ServiceHandler(private val parserRegistry: ServiceParserRegistry) {
     /**
      * Parses a service from RDF graph data and returns it as JSON.
      *
@@ -40,11 +38,7 @@ class ServiceHandler(
      * @throws NoAcceptableFDKRecordsException if no service is found with the given identifier
      * @throws IllegalStateException if no parsers can successfully parse the service
      */
-    fun parseService(
-        fdkId: String,
-        graph: String,
-        catalogGraph: String?,
-    ): JsonNode {
+    fun parseService(fdkId: String, graph: String, catalogGraph: String?): JsonNode {
         val model = ModelFactory.createDefaultModel()
         val service: no.digdir.fdk.model.service.Service =
             try {

--- a/src/main/kotlin/no/digdir/fdk/parserservice/kafka/KafkaHarvestEventProducer.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/kafka/KafkaHarvestEventProducer.kt
@@ -10,9 +10,7 @@ import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
 
 @Component
-class KafkaHarvestEventProducer(
-    private val kafkaTemplate: KafkaTemplate<String, HarvestEvent>,
-) {
+class KafkaHarvestEventProducer(private val kafkaTemplate: KafkaTemplate<String, HarvestEvent>) {
     fun sendMessage(msg: HarvestEvent) {
         LOGGER.debug("Sending harvest event to Kafka topic: $TOPIC_NAME")
         val type = msg.dataType.name.lowercase()

--- a/src/main/kotlin/no/digdir/fdk/parserservice/kafka/KafkaManager.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/kafka/KafkaManager.kt
@@ -6,9 +6,7 @@ import org.springframework.kafka.config.KafkaListenerEndpointRegistry
 import org.springframework.stereotype.Component
 
 @Component
-class KafkaManager(
-    private val registry: KafkaListenerEndpointRegistry,
-) {
+class KafkaManager(private val registry: KafkaListenerEndpointRegistry) {
     fun pause(id: String) {
         LOGGER.debug("Pausing kafka listener containers with id: $id")
         registry.listenerContainers

--- a/src/main/kotlin/no/digdir/fdk/parserservice/kafka/KafkaRdfParseEventProducer.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/kafka/KafkaRdfParseEventProducer.kt
@@ -11,9 +11,7 @@ import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
 
 @Component
-class KafkaRdfParseEventProducer(
-    private val kafkaTemplate: KafkaTemplate<String, RdfParseEvent>,
-) {
+class KafkaRdfParseEventProducer(private val kafkaTemplate: KafkaTemplate<String, RdfParseEvent>) {
     fun sendMessage(msg: RdfParseEvent) {
         LOGGER.debug("Sending message to Kafka topic: $TOPIC_NAME")
         val type = ParseMetrics.metricType(msg.resourceType)

--- a/src/main/kotlin/no/digdir/fdk/parserservice/kafka/KafkaReasonedEventCircuitBreaker.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/kafka/KafkaReasonedEventCircuitBreaker.kt
@@ -47,156 +47,144 @@ class KafkaReasonedEventCircuitBreaker(
     private val serviceHandler: ServiceHandler,
     private val circuitBreakerRegistry: CircuitBreakerRegistry,
 ) {
-    fun processConceptGeneric(event: GenericRecord): ProcessOutcome =
-        executeWithCircuitBreaker("rdf-parse-concept") {
-            processGeneric(event, ConceptEventType.CONCEPT_REASONED.name, RdfParseResourceType.CONCEPT, "concept")
-        }
+    fun processConceptGeneric(event: GenericRecord): ProcessOutcome = executeWithCircuitBreaker("rdf-parse-concept") {
+        processGeneric(event, ConceptEventType.CONCEPT_REASONED.name, RdfParseResourceType.CONCEPT, "concept")
+    }
 
-    fun processDataServiceGeneric(event: GenericRecord): ProcessOutcome =
-        executeWithCircuitBreaker("rdf-parse-data-service") {
-            processGeneric(event, DataServiceEventType.DATA_SERVICE_REASONED.name, RdfParseResourceType.DATA_SERVICE, "data service")
-        }
+    fun processDataServiceGeneric(event: GenericRecord): ProcessOutcome = executeWithCircuitBreaker("rdf-parse-data-service") {
+        processGeneric(event, DataServiceEventType.DATA_SERVICE_REASONED.name, RdfParseResourceType.DATA_SERVICE, "data service")
+    }
 
-    fun processDatasetGeneric(event: GenericRecord): ProcessOutcome =
-        executeWithCircuitBreaker("rdf-parse-dataset") {
-            processGeneric(event, DatasetEventType.DATASET_REASONED.name, RdfParseResourceType.DATASET, "dataset")
-        }
+    fun processDatasetGeneric(event: GenericRecord): ProcessOutcome = executeWithCircuitBreaker("rdf-parse-dataset") {
+        processGeneric(event, DatasetEventType.DATASET_REASONED.name, RdfParseResourceType.DATASET, "dataset")
+    }
 
-    fun processInformationModelGeneric(event: GenericRecord): ProcessOutcome =
-        executeWithCircuitBreaker("rdf-parse-information-model") {
-            processGeneric(
-                event,
-                InformationModelEventType.INFORMATION_MODEL_REASONED.name,
-                RdfParseResourceType.INFORMATION_MODEL,
-                "information model",
+    fun processInformationModelGeneric(event: GenericRecord): ProcessOutcome = executeWithCircuitBreaker("rdf-parse-information-model") {
+        processGeneric(
+            event,
+            InformationModelEventType.INFORMATION_MODEL_REASONED.name,
+            RdfParseResourceType.INFORMATION_MODEL,
+            "information model",
+        )
+    }
+
+    fun processServiceGeneric(event: GenericRecord): ProcessOutcome = executeWithCircuitBreaker("rdf-parse-service") {
+        processGeneric(event, ServiceEventType.SERVICE_REASONED.name, RdfParseResourceType.SERVICE, "service")
+    }
+
+    fun processEventGeneric(event: GenericRecord): ProcessOutcome = executeWithCircuitBreaker("rdf-parse-event") {
+        processGeneric(event, EventEventType.EVENT_REASONED.name, RdfParseResourceType.EVENT, "event")
+    }
+
+    fun processConcept(event: ConceptEvent): ProcessOutcome = processTypedEvent(
+        circuitBreakerName = "rdf-parse-concept",
+        resourceType = RdfParseResourceType.CONCEPT,
+        resourceLabel = "concept",
+        event = event,
+        isExpectedType = { runCatching { it.type }.getOrNull() == ConceptEventType.CONCEPT_REASONED },
+        extractFields = {
+            extractReasonedEventFields(
+                fdkId = { it.fdkId },
+                graph = { it.graph },
+                timestamp = { it.timestamp },
+                harvestRunId = { it.harvestRunId },
+                uri = { it.uri },
+                catalogGraph = { it.catalogGraph },
             )
-        }
+        },
+    )
 
-    fun processServiceGeneric(event: GenericRecord): ProcessOutcome =
-        executeWithCircuitBreaker("rdf-parse-service") {
-            processGeneric(event, ServiceEventType.SERVICE_REASONED.name, RdfParseResourceType.SERVICE, "service")
-        }
+    fun processDataService(event: DataServiceEvent): ProcessOutcome = processTypedEvent(
+        circuitBreakerName = "rdf-parse-data-service",
+        resourceType = RdfParseResourceType.DATA_SERVICE,
+        resourceLabel = "data service",
+        event = event,
+        isExpectedType = { runCatching { it.type }.getOrNull() == DataServiceEventType.DATA_SERVICE_REASONED },
+        extractFields = {
+            extractReasonedEventFields(
+                fdkId = { it.fdkId },
+                graph = { it.graph },
+                timestamp = { it.timestamp },
+                harvestRunId = { it.harvestRunId },
+                uri = { it.uri },
+                catalogGraph = { it.catalogGraph },
+            )
+        },
+    )
 
-    fun processEventGeneric(event: GenericRecord): ProcessOutcome =
-        executeWithCircuitBreaker("rdf-parse-event") {
-            processGeneric(event, EventEventType.EVENT_REASONED.name, RdfParseResourceType.EVENT, "event")
-        }
+    fun processDataset(event: DatasetEvent): ProcessOutcome = processTypedEvent(
+        circuitBreakerName = "rdf-parse-dataset",
+        resourceType = RdfParseResourceType.DATASET,
+        resourceLabel = "dataset",
+        event = event,
+        isExpectedType = { runCatching { it.type }.getOrNull() == DatasetEventType.DATASET_REASONED },
+        extractFields = {
+            extractReasonedEventFields(
+                fdkId = { it.fdkId },
+                graph = { it.graph },
+                timestamp = { it.timestamp },
+                harvestRunId = { it.harvestRunId },
+                uri = { it.uri },
+                catalogGraph = { it.catalogGraph },
+            )
+        },
+    )
 
-    fun processConcept(event: ConceptEvent): ProcessOutcome =
-        processTypedEvent(
-            circuitBreakerName = "rdf-parse-concept",
-            resourceType = RdfParseResourceType.CONCEPT,
-            resourceLabel = "concept",
-            event = event,
-            isExpectedType = { runCatching { it.type }.getOrNull() == ConceptEventType.CONCEPT_REASONED },
-            extractFields = {
-                extractReasonedEventFields(
-                    fdkId = { it.fdkId },
-                    graph = { it.graph },
-                    timestamp = { it.timestamp },
-                    harvestRunId = { it.harvestRunId },
-                    uri = { it.uri },
-                    catalogGraph = { it.catalogGraph },
-                )
-            },
-        )
+    fun processInformationModel(event: InformationModelEvent): ProcessOutcome = processTypedEvent(
+        circuitBreakerName = "rdf-parse-information-model",
+        resourceType = RdfParseResourceType.INFORMATION_MODEL,
+        resourceLabel = "information model",
+        event = event,
+        isExpectedType = {
+            runCatching { it.type }.getOrNull() == InformationModelEventType.INFORMATION_MODEL_REASONED
+        },
+        extractFields = {
+            extractReasonedEventFields(
+                fdkId = { it.fdkId },
+                graph = { it.graph },
+                timestamp = { it.timestamp },
+                harvestRunId = { it.harvestRunId },
+                uri = { it.uri },
+                catalogGraph = { it.catalogGraph },
+            )
+        },
+    )
 
-    fun processDataService(event: DataServiceEvent): ProcessOutcome =
-        processTypedEvent(
-            circuitBreakerName = "rdf-parse-data-service",
-            resourceType = RdfParseResourceType.DATA_SERVICE,
-            resourceLabel = "data service",
-            event = event,
-            isExpectedType = { runCatching { it.type }.getOrNull() == DataServiceEventType.DATA_SERVICE_REASONED },
-            extractFields = {
-                extractReasonedEventFields(
-                    fdkId = { it.fdkId },
-                    graph = { it.graph },
-                    timestamp = { it.timestamp },
-                    harvestRunId = { it.harvestRunId },
-                    uri = { it.uri },
-                    catalogGraph = { it.catalogGraph },
-                )
-            },
-        )
+    fun processService(event: ServiceEvent): ProcessOutcome = processTypedEvent(
+        circuitBreakerName = "rdf-parse-service",
+        resourceType = RdfParseResourceType.SERVICE,
+        resourceLabel = "service",
+        event = event,
+        isExpectedType = { runCatching { it.type }.getOrNull() == ServiceEventType.SERVICE_REASONED },
+        extractFields = {
+            extractReasonedEventFields(
+                fdkId = { it.fdkId },
+                graph = { it.graph },
+                timestamp = { it.timestamp },
+                harvestRunId = { it.harvestRunId },
+                uri = { it.uri },
+                catalogGraph = { it.catalogGraph },
+            )
+        },
+    )
 
-    fun processDataset(event: DatasetEvent): ProcessOutcome =
-        processTypedEvent(
-            circuitBreakerName = "rdf-parse-dataset",
-            resourceType = RdfParseResourceType.DATASET,
-            resourceLabel = "dataset",
-            event = event,
-            isExpectedType = { runCatching { it.type }.getOrNull() == DatasetEventType.DATASET_REASONED },
-            extractFields = {
-                extractReasonedEventFields(
-                    fdkId = { it.fdkId },
-                    graph = { it.graph },
-                    timestamp = { it.timestamp },
-                    harvestRunId = { it.harvestRunId },
-                    uri = { it.uri },
-                    catalogGraph = { it.catalogGraph },
-                )
-            },
-        )
-
-    fun processInformationModel(event: InformationModelEvent): ProcessOutcome =
-        processTypedEvent(
-            circuitBreakerName = "rdf-parse-information-model",
-            resourceType = RdfParseResourceType.INFORMATION_MODEL,
-            resourceLabel = "information model",
-            event = event,
-            isExpectedType = {
-                runCatching { it.type }.getOrNull() == InformationModelEventType.INFORMATION_MODEL_REASONED
-            },
-            extractFields = {
-                extractReasonedEventFields(
-                    fdkId = { it.fdkId },
-                    graph = { it.graph },
-                    timestamp = { it.timestamp },
-                    harvestRunId = { it.harvestRunId },
-                    uri = { it.uri },
-                    catalogGraph = { it.catalogGraph },
-                )
-            },
-        )
-
-    fun processService(event: ServiceEvent): ProcessOutcome =
-        processTypedEvent(
-            circuitBreakerName = "rdf-parse-service",
-            resourceType = RdfParseResourceType.SERVICE,
-            resourceLabel = "service",
-            event = event,
-            isExpectedType = { runCatching { it.type }.getOrNull() == ServiceEventType.SERVICE_REASONED },
-            extractFields = {
-                extractReasonedEventFields(
-                    fdkId = { it.fdkId },
-                    graph = { it.graph },
-                    timestamp = { it.timestamp },
-                    harvestRunId = { it.harvestRunId },
-                    uri = { it.uri },
-                    catalogGraph = { it.catalogGraph },
-                )
-            },
-        )
-
-    fun processEvent(event: EventEvent): ProcessOutcome =
-        processTypedEvent(
-            circuitBreakerName = "rdf-parse-event",
-            resourceType = RdfParseResourceType.EVENT,
-            resourceLabel = "event",
-            event = event,
-            isExpectedType = { runCatching { it.type }.getOrNull() == EventEventType.EVENT_REASONED },
-            extractFields = {
-                extractReasonedEventFields(
-                    fdkId = { it.fdkId },
-                    graph = { it.graph },
-                    timestamp = { it.timestamp },
-                    harvestRunId = { it.harvestRunId },
-                    uri = { it.uri },
-                    catalogGraph = { it.catalogGraph },
-                )
-            },
-        )
+    fun processEvent(event: EventEvent): ProcessOutcome = processTypedEvent(
+        circuitBreakerName = "rdf-parse-event",
+        resourceType = RdfParseResourceType.EVENT,
+        resourceLabel = "event",
+        event = event,
+        isExpectedType = { runCatching { it.type }.getOrNull() == EventEventType.EVENT_REASONED },
+        extractFields = {
+            extractReasonedEventFields(
+                fdkId = { it.fdkId },
+                graph = { it.graph },
+                timestamp = { it.timestamp },
+                harvestRunId = { it.harvestRunId },
+                uri = { it.uri },
+                catalogGraph = { it.catalogGraph },
+            )
+        },
+    )
 
     private inline fun <T> processTypedEvent(
         circuitBreakerName: String,
@@ -205,35 +193,34 @@ class KafkaReasonedEventCircuitBreaker(
         event: T,
         crossinline isExpectedType: (T) -> Boolean,
         crossinline extractFields: (T) -> ReasonedEventFields,
-    ): ProcessOutcome =
-        executeWithCircuitBreaker(circuitBreakerName) {
-            if (!isExpectedType(event)) {
-                return@executeWithCircuitBreaker ProcessOutcome.Skipped
-            }
-
-            val fields = extractFields(event)
-            if (fields.fdkId != null && fields.graph != null && fields.timestamp != null) {
-                handleRecord(
-                    fdkId = fields.fdkId,
-                    graph = fields.graph,
-                    timestamp = fields.timestamp,
-                    resourceType = resourceType,
-                    harvestRunId = fields.harvestRunId,
-                    uri = fields.uri,
-                    catalogGraph = fields.catalogGraph,
-                )
-                ProcessOutcome.Success(resourceType)
-            } else {
-                val graphForLog = fields.graph?.let { truncateForLog(it, MAX_GRAPH_LOG_LENGTH) }
-                LOGGER.warn(
-                    "Ignoring $resourceLabel message with missing required fields. fdkId: {}, graph: {}, timestamp: {}",
-                    fields.fdkId,
-                    graphForLog,
-                    fields.timestamp,
-                )
-                ProcessOutcome.Skipped
-            }
+    ): ProcessOutcome = executeWithCircuitBreaker(circuitBreakerName) {
+        if (!isExpectedType(event)) {
+            return@executeWithCircuitBreaker ProcessOutcome.Skipped
         }
+
+        val fields = extractFields(event)
+        if (fields.fdkId != null && fields.graph != null && fields.timestamp != null) {
+            handleRecord(
+                fdkId = fields.fdkId,
+                graph = fields.graph,
+                timestamp = fields.timestamp,
+                resourceType = resourceType,
+                harvestRunId = fields.harvestRunId,
+                uri = fields.uri,
+                catalogGraph = fields.catalogGraph,
+            )
+            ProcessOutcome.Success(resourceType)
+        } else {
+            val graphForLog = fields.graph?.let { truncateForLog(it, MAX_GRAPH_LOG_LENGTH) }
+            LOGGER.warn(
+                "Ignoring $resourceLabel message with missing required fields. fdkId: {}, graph: {}, timestamp: {}",
+                fields.fdkId,
+                graphForLog,
+                fields.timestamp,
+            )
+            ProcessOutcome.Skipped
+        }
+    }
 
     private fun extractReasonedEventFields(
         fdkId: () -> Any?,
@@ -242,15 +229,14 @@ class KafkaReasonedEventCircuitBreaker(
         harvestRunId: () -> Any?,
         uri: () -> Any?,
         catalogGraph: () -> Any?,
-    ): ReasonedEventFields =
-        ReasonedEventFields(
-            fdkId = runCatching { fdkId()?.toString() }.getOrNull(),
-            graph = runCatching { graph()?.toString() }.getOrNull(),
-            timestamp = runCatching { timestamp() }.getOrNull(),
-            harvestRunId = runCatching { harvestRunId()?.toString() }.getOrNull(),
-            uri = runCatching { uri()?.toString() }.getOrNull(),
-            catalogGraph = runCatching { catalogGraph()?.toString() }.getOrNull(),
-        )
+    ): ReasonedEventFields = ReasonedEventFields(
+        fdkId = runCatching { fdkId()?.toString() }.getOrNull(),
+        graph = runCatching { graph()?.toString() }.getOrNull(),
+        timestamp = runCatching { timestamp() }.getOrNull(),
+        harvestRunId = runCatching { harvestRunId()?.toString() }.getOrNull(),
+        uri = runCatching { uri()?.toString() }.getOrNull(),
+        catalogGraph = runCatching { catalogGraph()?.toString() }.getOrNull(),
+    )
 
     private data class ReasonedEventFields(
         val fdkId: String?,
@@ -261,13 +247,9 @@ class KafkaReasonedEventCircuitBreaker(
         val catalogGraph: String?,
     )
 
-    private fun executeWithCircuitBreaker(
-        circuitBreakerName: String,
-        block: () -> ProcessOutcome,
-    ): ProcessOutcome =
-        circuitBreakerRegistry
-            .circuitBreaker(circuitBreakerName)
-            .executeSupplier(block)
+    private fun executeWithCircuitBreaker(circuitBreakerName: String, block: () -> ProcessOutcome): ProcessOutcome = circuitBreakerRegistry
+        .circuitBreaker(circuitBreakerName)
+        .executeSupplier(block)
 
     private fun processGeneric(
         event: GenericRecord,
@@ -425,15 +407,14 @@ class KafkaReasonedEventCircuitBreaker(
         ParseMetrics.recordTotal(type, timeElapsed.duration)
     }
 
-    private fun mapResourceTypeToDataType(resourceType: RdfParseResourceType): DataType =
-        when (resourceType) {
-            RdfParseResourceType.DATASET -> DataType.dataset
-            RdfParseResourceType.DATA_SERVICE -> DataType.dataservice
-            RdfParseResourceType.INFORMATION_MODEL -> DataType.informationmodel
-            RdfParseResourceType.CONCEPT -> DataType.concept
-            RdfParseResourceType.SERVICE -> DataType.publicService
-            RdfParseResourceType.EVENT -> DataType.event
-        }
+    private fun mapResourceTypeToDataType(resourceType: RdfParseResourceType): DataType = when (resourceType) {
+        RdfParseResourceType.DATASET -> DataType.dataset
+        RdfParseResourceType.DATA_SERVICE -> DataType.dataservice
+        RdfParseResourceType.INFORMATION_MODEL -> DataType.informationmodel
+        RdfParseResourceType.CONCEPT -> DataType.concept
+        RdfParseResourceType.SERVICE -> DataType.publicService
+        RdfParseResourceType.EVENT -> DataType.event
+    }
 
     private fun produceHarvestEvent(
         harvestRunId: String?,
@@ -469,28 +450,20 @@ class KafkaReasonedEventCircuitBreaker(
     sealed class ProcessOutcome {
         data object Skipped : ProcessOutcome()
 
-        data class Success(
-            val resourceType: RdfParseResourceType,
-        ) : ProcessOutcome()
+        data class Success(val resourceType: RdfParseResourceType) : ProcessOutcome()
     }
 
     companion object {
         private const val MAX_GRAPH_LOG_LENGTH = 200
         private val LOGGER: Logger = LoggerFactory.getLogger(KafkaReasonedEventCircuitBreaker::class.java)
 
-        private fun truncateForLog(
-            s: String,
-            maxLength: Int,
-        ): String = if (s.length <= maxLength) s else s.take(maxLength) + "... (${s.length} chars total)"
+        private fun truncateForLog(s: String, maxLength: Int): String =
+            if (s.length <= maxLength) s else s.take(maxLength) + "... (${s.length} chars total)"
     }
 }
 
-class RecoverableParseProcessingException(
-    val resourceType: RdfParseResourceType,
-    cause: Throwable,
-) : RuntimeException(cause.message, cause)
+class RecoverableParseProcessingException(val resourceType: RdfParseResourceType, cause: Throwable) :
+    RuntimeException(cause.message, cause)
 
-class UnrecoverableParseProcessingException(
-    val resourceType: RdfParseResourceType,
-    cause: Throwable,
-) : RuntimeException(cause.message, cause)
+class UnrecoverableParseProcessingException(val resourceType: RdfParseResourceType, cause: Throwable) :
+    RuntimeException(cause.message, cause)

--- a/src/main/kotlin/no/digdir/fdk/parserservice/kafka/KafkaReasonedEventConsumer.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/kafka/KafkaReasonedEventConsumer.kt
@@ -21,9 +21,7 @@ import org.springframework.stereotype.Component
 import java.time.Duration
 
 @Component
-class KafkaReasonedEventConsumer(
-    private val circuitBreaker: KafkaReasonedEventCircuitBreaker,
-) {
+class KafkaReasonedEventConsumer(private val circuitBreaker: KafkaReasonedEventCircuitBreaker) {
     @KafkaListener(
         topics = ["data-service-events"],
         groupId = "fdk-parser-service",
@@ -31,10 +29,7 @@ class KafkaReasonedEventConsumer(
         containerFactory = "kafkaListenerContainerFactory",
         id = "data-service-event-consumer",
     )
-    fun dataServiceListener(
-        record: ConsumerRecord<String, Any>,
-        ack: Acknowledgment,
-    ) {
+    fun dataServiceListener(record: ConsumerRecord<String, Any>, ack: Acknowledgment) {
         handleListenerMessage<DataServiceEvent>(
             record = record,
             ack = ack,
@@ -51,10 +46,7 @@ class KafkaReasonedEventConsumer(
         containerFactory = "kafkaListenerContainerFactory",
         id = "concept-event-consumer",
     )
-    fun conceptListener(
-        record: ConsumerRecord<String, Any>,
-        ack: Acknowledgment,
-    ) {
+    fun conceptListener(record: ConsumerRecord<String, Any>, ack: Acknowledgment) {
         handleListenerMessage<ConceptEvent>(
             record = record,
             ack = ack,
@@ -71,10 +63,7 @@ class KafkaReasonedEventConsumer(
         containerFactory = "kafkaListenerContainerFactory",
         id = "dataset-event-consumer",
     )
-    fun datasetListener(
-        record: ConsumerRecord<String, Any>,
-        ack: Acknowledgment,
-    ) {
+    fun datasetListener(record: ConsumerRecord<String, Any>, ack: Acknowledgment) {
         handleListenerMessage<DatasetEvent>(
             record = record,
             ack = ack,
@@ -91,10 +80,7 @@ class KafkaReasonedEventConsumer(
         containerFactory = "kafkaListenerContainerFactory",
         id = "information-model-event-consumer",
     )
-    fun informationModelListener(
-        record: ConsumerRecord<String, Any>,
-        ack: Acknowledgment,
-    ) {
+    fun informationModelListener(record: ConsumerRecord<String, Any>, ack: Acknowledgment) {
         handleListenerMessage<InformationModelEvent>(
             record = record,
             ack = ack,
@@ -111,10 +97,7 @@ class KafkaReasonedEventConsumer(
         containerFactory = "kafkaListenerContainerFactory",
         id = "service-event-consumer",
     )
-    fun serviceListener(
-        record: ConsumerRecord<String, Any>,
-        ack: Acknowledgment,
-    ) {
+    fun serviceListener(record: ConsumerRecord<String, Any>, ack: Acknowledgment) {
         handleListenerMessage<ServiceEvent>(
             record = record,
             ack = ack,
@@ -131,10 +114,7 @@ class KafkaReasonedEventConsumer(
         containerFactory = "kafkaListenerContainerFactory",
         id = "event-event-consumer",
     )
-    fun eventListener(
-        record: ConsumerRecord<String, Any>,
-        ack: Acknowledgment,
-    ) {
+    fun eventListener(record: ConsumerRecord<String, Any>, ack: Acknowledgment) {
         handleListenerMessage<EventEvent>(
             record = record,
             ack = ack,

--- a/src/main/kotlin/no/digdir/fdk/parserservice/metrics/KafkaParseMetrics.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/metrics/KafkaParseMetrics.kt
@@ -23,17 +23,11 @@ object KafkaParseMetrics {
         ensureListenerPausedGaugeRegistered(listenerId)
     }
 
-    fun setListenerPaused(
-        listenerId: String,
-        paused: Boolean,
-    ) {
+    fun setListenerPaused(listenerId: String, paused: Boolean) {
         ensureListenerPausedGaugeRegistered(listenerId).set(if (paused) 1 else 0)
     }
 
-    fun recordEventProcessed(
-        resourceType: RdfParseResourceType?,
-        result: EventProcessingResult,
-    ) {
+    fun recordEventProcessed(resourceType: RdfParseResourceType?, result: EventProcessingResult) {
         registry
             .counter(
                 "rdf_parse_event_processing_total",
@@ -56,9 +50,7 @@ object KafkaParseMetrics {
         return state
     }
 
-    enum class EventProcessingResult(
-        val label: String,
-    ) {
+    enum class EventProcessingResult(val label: String) {
         ACKED("acked"),
         NACKED("nacked"),
         SKIPPED("skipped"),

--- a/src/main/kotlin/no/digdir/fdk/parserservice/metrics/ParseMetrics.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/metrics/ParseMetrics.kt
@@ -14,10 +14,7 @@ object ParseMetrics {
         this.registry = registry
     }
 
-    fun recordTotal(
-        resourceType: RdfParseResourceType,
-        duration: Duration,
-    ) {
+    fun recordTotal(resourceType: RdfParseResourceType, duration: Duration) {
         registry
             .timer(
                 "rdf_parse",
@@ -27,10 +24,7 @@ object ParseMetrics {
     }
 
     /** Records a parsing failure, tagged with a `reason` derived from the simple class name. */
-    fun recordError(
-        resourceType: RdfParseResourceType,
-        cause: Throwable,
-    ) {
+    fun recordError(resourceType: RdfParseResourceType, cause: Throwable) {
         registry
             .counter(
                 "rdf_parse_error",
@@ -42,11 +36,7 @@ object ParseMetrics {
     }
 
     /** Records whether a specific parser implementation matched (parsed) a resource. */
-    fun recordProfileMatch(
-        resourceType: RdfParseResourceType,
-        parserName: String,
-        matched: Boolean,
-    ) {
+    fun recordProfileMatch(resourceType: RdfParseResourceType, parserName: String, matched: Boolean) {
         registry
             .counter(
                 "rdf_parse_profile_match_total",
@@ -60,10 +50,7 @@ object ParseMetrics {
     }
 
     /** Records the end-to-end lag between when the reasoned event was produced and when parsing started. */
-    fun recordPipelineLag(
-        resourceType: RdfParseResourceType,
-        lagMillis: Long,
-    ) {
+    fun recordPipelineLag(resourceType: RdfParseResourceType, lagMillis: Long) {
         registry
             .timer(
                 "rdf_parse_pipeline_lag",
@@ -73,11 +60,7 @@ object ParseMetrics {
     }
 
     /** Records the size (in characters) of an input RDF graph or output JSON payload. */
-    fun recordPayloadSize(
-        resourceType: RdfParseResourceType,
-        direction: PayloadDirection,
-        sizeChars: Int,
-    ) {
+    fun recordPayloadSize(resourceType: RdfParseResourceType, direction: PayloadDirection, sizeChars: Int) {
         registry
             .summary(
                 "rdf_parse_payload_size_chars",
@@ -96,15 +79,12 @@ object ParseMetrics {
         return toSnakeCase(withoutSuffix)
     }
 
-    private fun toSnakeCase(value: String): String =
-        value
-            .replace(Regex("(?<=[a-z0-9])(?=[A-Z])"), "_")
-            .replace(Regex("(?<=[A-Z])(?=[A-Z][a-z])"), "_")
-            .lowercase()
+    private fun toSnakeCase(value: String): String = value
+        .replace(Regex("(?<=[a-z0-9])(?=[A-Z])"), "_")
+        .replace(Regex("(?<=[A-Z])(?=[A-Z][a-z])"), "_")
+        .lowercase()
 
-    enum class PayloadDirection(
-        val label: String,
-    ) {
+    enum class PayloadDirection(val label: String) {
         INPUT("input"),
         OUTPUT("output"),
     }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/metrics/RdfParseEventMetrics.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/metrics/RdfParseEventMetrics.kt
@@ -10,11 +10,7 @@ object RdfParseEventMetrics {
         this.registry = registry
     }
 
-    fun recordPublish(
-        type: String,
-        kind: PublishKind,
-        outcome: PublishOutcome,
-    ) {
+    fun recordPublish(type: String, kind: PublishKind, outcome: PublishOutcome) {
         registry
             .counter(
                 "rdf_parse_event_publish_total",
@@ -29,17 +25,12 @@ object RdfParseEventMetrics {
             ).increment()
     }
 
-    enum class PublishKind(
-        val label: String,
-    ) {
+    enum class PublishKind(val label: String) {
         PARSED("parsed"),
         HARVEST("harvest"),
     }
 
-    enum class PublishOutcome(
-        val status: String,
-        val reason: String,
-    ) {
+    enum class PublishOutcome(val status: String, val reason: String) {
         SUCCESS("success", "published"),
         PUBLISH_FAILED("error", "publish_failed"),
         SKIPPED("error", "skipped"),

--- a/src/main/kotlin/no/digdir/fdk/parserservice/model/Exceptions.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/model/Exceptions.kt
@@ -1,36 +1,17 @@
 package no.digdir.fdk.parserservice.model
 
-open class RecoverableParseException(
-    message: String,
-    cause: Throwable? = null,
-) : Exception(message, cause)
+open class RecoverableParseException(message: String, cause: Throwable? = null) : Exception(message, cause)
 
-open class UnrecoverableParseException(
-    message: String,
-    cause: Throwable? = null,
-) : Exception(message, cause)
+open class UnrecoverableParseException(message: String, cause: Throwable? = null) : Exception(message, cause)
 
-class NoAcceptableFDKRecordsException(
-    message: String,
-) : RecoverableParseException(message)
+class NoAcceptableFDKRecordsException(message: String) : RecoverableParseException(message)
 
-class MultipleFDKRecordsException(
-    message: String,
-) : RecoverableParseException(message)
+class MultipleFDKRecordsException(message: String) : RecoverableParseException(message)
 
-class NoAcceptableTypesException(
-    message: String,
-) : RecoverableParseException(message)
+class NoAcceptableTypesException(message: String) : RecoverableParseException(message)
 
-class NoResourceFoundException(
-    message: String,
-) : RecoverableParseException(message)
+class NoResourceFoundException(message: String) : RecoverableParseException(message)
 
-class UnableToParseException(
-    message: String,
-) : UnrecoverableParseException(message)
+class UnableToParseException(message: String) : UnrecoverableParseException(message)
 
-class NoParserMatchedException(
-    message: String,
-    cause: Throwable? = null,
-) : UnrecoverableParseException(message, cause)
+class NoParserMatchedException(message: String, cause: Throwable? = null) : UnrecoverableParseException(message, cause)

--- a/src/main/kotlin/no/digdir/fdk/parserservice/model/LanguageCodes.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/model/LanguageCodes.kt
@@ -1,8 +1,6 @@
 package no.digdir.fdk.parserservice.model
 
-enum class LanguageCodes(
-    val code: String,
-) {
+enum class LanguageCodes(val code: String) {
     NORWEGIAN_BOKMAL("nb"),
     NORWEGIAN_NYNORSK("nn"),
     ENGLISH("en"),
@@ -13,10 +11,9 @@ enum class LanguageCodes(
     companion object {
         private val byCode = entries.filter { it != NONE }.associateBy { it.code }
 
-        fun fromCode(code: String?): LanguageCodes? =
-            when {
-                code == null || code.isEmpty() -> NONE
-                else -> byCode[code]
-            }
+        fun fromCode(code: String?): LanguageCodes? = when {
+            code == null || code.isEmpty() -> NONE
+            else -> byCode[code]
+        }
     }
 }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/ConceptParserRegistry.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/ConceptParserRegistry.kt
@@ -30,11 +30,7 @@ class ConceptParserRegistry {
      * @param priority The priority level (higher = more priority)
      * @param name Human-readable name for logging
      */
-    fun registerParser(
-        parser: ConceptParserStrategy,
-        priority: Int,
-        name: String,
-    ) {
+    fun registerParser(parser: ConceptParserStrategy, priority: Int, name: String) {
         parsers.add(ParserEntry(parser, priority, name))
         parsers.sortByDescending { it.priority }
         LOGGER.info("Registered concept parser '$name' with priority $priority")
@@ -48,11 +44,7 @@ class ConceptParserRegistry {
      * @param fdkId The FDK ID of the resource
      * @return List of successfully parsed concepts in priority order
      */
-    fun parseWithAllParsers(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): List<Concept> {
+    fun parseWithAllParsers(model: Model, iri: String, fdkId: String): List<Concept> {
         val results = mutableListOf<Concept>()
 
         for (entry in parsers) {
@@ -83,25 +75,17 @@ class ConceptParserRegistry {
     /**
      * Gets information about registered parsers.
      */
-    fun getParserInfo(): List<ParserInfo> =
-        parsers.map {
-            ParserInfo(it.name, it.priority)
-        }
+    fun getParserInfo(): List<ParserInfo> = parsers.map {
+        ParserInfo(it.name, it.priority)
+    }
 
     /**
      * Internal data class for storing parser entries.
      */
-    private data class ParserEntry(
-        val parser: ConceptParserStrategy,
-        val priority: Int,
-        val name: String,
-    )
+    private data class ParserEntry(val parser: ConceptParserStrategy, val priority: Int, val name: String)
 
     /**
      * Data class for parser information.
      */
-    data class ParserInfo(
-        val name: String,
-        val priority: Int,
-    )
+    data class ParserInfo(val name: String, val priority: Int)
 }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/DataServiceParserRegistry.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/DataServiceParserRegistry.kt
@@ -30,11 +30,7 @@ class DataServiceParserRegistry {
      * @param priority The priority level (higher = more priority)
      * @param name Human-readable name for logging
      */
-    fun registerParser(
-        parser: DataServiceParserStrategy,
-        priority: Int,
-        name: String,
-    ) {
+    fun registerParser(parser: DataServiceParserStrategy, priority: Int, name: String) {
         parsers.add(ParserEntry(parser, priority, name))
         parsers.sortByDescending { it.priority }
         LOGGER.info("Registered data service parser '$name' with priority $priority")
@@ -48,11 +44,7 @@ class DataServiceParserRegistry {
      * @param fdkId The FDK ID of the resource
      * @return List of successfully parsed data services in priority order
      */
-    fun parseWithAllParsers(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): List<DataService> {
+    fun parseWithAllParsers(model: Model, iri: String, fdkId: String): List<DataService> {
         val results = mutableListOf<DataService>()
 
         for (entry in parsers) {
@@ -83,25 +75,17 @@ class DataServiceParserRegistry {
     /**
      * Gets information about registered parsers.
      */
-    fun getParserInfo(): List<ParserInfo> =
-        parsers.map {
-            ParserInfo(it.name, it.priority)
-        }
+    fun getParserInfo(): List<ParserInfo> = parsers.map {
+        ParserInfo(it.name, it.priority)
+    }
 
     /**
      * Internal data class for storing parser entries.
      */
-    private data class ParserEntry(
-        val parser: DataServiceParserStrategy,
-        val priority: Int,
-        val name: String,
-    )
+    private data class ParserEntry(val parser: DataServiceParserStrategy, val priority: Int, val name: String)
 
     /**
      * Data class for parser information.
      */
-    data class ParserInfo(
-        val name: String,
-        val priority: Int,
-    )
+    data class ParserInfo(val name: String, val priority: Int)
 }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/DatasetParserRegistry.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/DatasetParserRegistry.kt
@@ -30,11 +30,7 @@ class DatasetParserRegistry {
      * @param priority The priority level (higher = more priority)
      * @param name Human-readable name for logging
      */
-    fun registerParser(
-        parser: DatasetParserStrategy,
-        priority: Int,
-        name: String,
-    ) {
+    fun registerParser(parser: DatasetParserStrategy, priority: Int, name: String) {
         parsers.add(ParserEntry(parser, priority, name))
         parsers.sortByDescending { it.priority }
         LOGGER.info("Registered dataset parser '$name' with priority $priority")
@@ -48,11 +44,7 @@ class DatasetParserRegistry {
      * @param fdkId The FDK ID of the resource
      * @return List of successfully parsed datasets in priority order
      */
-    fun parseWithAllParsers(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): List<Dataset> {
+    fun parseWithAllParsers(model: Model, iri: String, fdkId: String): List<Dataset> {
         val results = mutableListOf<Dataset>()
 
         for (entry in parsers) {
@@ -83,25 +75,17 @@ class DatasetParserRegistry {
     /**
      * Gets information about registered parsers.
      */
-    fun getParserInfo(): List<ParserInfo> =
-        parsers.map {
-            ParserInfo(it.name, it.priority)
-        }
+    fun getParserInfo(): List<ParserInfo> = parsers.map {
+        ParserInfo(it.name, it.priority)
+    }
 
     /**
      * Internal data class for storing parser entries.
      */
-    private data class ParserEntry(
-        val parser: DatasetParserStrategy,
-        val priority: Int,
-        val name: String,
-    )
+    private data class ParserEntry(val parser: DatasetParserStrategy, val priority: Int, val name: String)
 
     /**
      * Data class for parser information.
      */
-    data class ParserInfo(
-        val name: String,
-        val priority: Int,
-    )
+    data class ParserInfo(val name: String, val priority: Int)
 }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/EventParserRegistry.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/EventParserRegistry.kt
@@ -30,11 +30,7 @@ class EventParserRegistry {
      * @param priority The priority level (higher = more priority)
      * @param name Human-readable name for logging
      */
-    fun registerParser(
-        parser: EventParserStrategy,
-        priority: Int,
-        name: String,
-    ) {
+    fun registerParser(parser: EventParserStrategy, priority: Int, name: String) {
         parsers.add(ParserEntry(parser, priority, name))
         parsers.sortByDescending { it.priority }
         LOGGER.info("Registered event parser '$name' with priority $priority")
@@ -48,11 +44,7 @@ class EventParserRegistry {
      * @param fdkId The FDK ID of the resource
      * @return List of successfully parsed events in priority order
      */
-    fun parseWithAllParsers(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): List<Event> {
+    fun parseWithAllParsers(model: Model, iri: String, fdkId: String): List<Event> {
         val results = mutableListOf<Event>()
 
         for (entry in parsers) {
@@ -83,25 +75,17 @@ class EventParserRegistry {
     /**
      * Gets information about registered parsers.
      */
-    fun getParserInfo(): List<ParserInfo> =
-        parsers.map {
-            ParserInfo(it.name, it.priority)
-        }
+    fun getParserInfo(): List<ParserInfo> = parsers.map {
+        ParserInfo(it.name, it.priority)
+    }
 
     /**
      * Internal data class for storing parser entries.
      */
-    private data class ParserEntry(
-        val parser: EventParserStrategy,
-        val priority: Int,
-        val name: String,
-    )
+    private data class ParserEntry(val parser: EventParserStrategy, val priority: Int, val name: String)
 
     /**
      * Data class for parser information.
      */
-    data class ParserInfo(
-        val name: String,
-        val priority: Int,
-    )
+    data class ParserInfo(val name: String, val priority: Int)
 }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/InformationModelParserRegistry.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/InformationModelParserRegistry.kt
@@ -30,11 +30,7 @@ class InformationModelParserRegistry {
      * @param priority The priority level (higher = more priority)
      * @param name Human-readable name for logging
      */
-    fun registerParser(
-        parser: InformationModelParserStrategy,
-        priority: Int,
-        name: String,
-    ) {
+    fun registerParser(parser: InformationModelParserStrategy, priority: Int, name: String) {
         parsers.add(ParserEntry(parser, priority, name))
         parsers.sortByDescending { it.priority }
         LOGGER.info("Registered information model parser '$name' with priority $priority")
@@ -48,11 +44,7 @@ class InformationModelParserRegistry {
      * @param fdkId The FDK ID of the resource
      * @return List of successfully parsed information models in priority order
      */
-    fun parseWithAllParsers(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): List<InformationModel> {
+    fun parseWithAllParsers(model: Model, iri: String, fdkId: String): List<InformationModel> {
         val results = mutableListOf<InformationModel>()
 
         for (entry in parsers) {
@@ -82,25 +74,17 @@ class InformationModelParserRegistry {
     /**
      * Gets information about registered parsers.
      */
-    fun getParserInfo(): List<ParserInfo> =
-        parsers.map {
-            ParserInfo(it.name, it.priority)
-        }
+    fun getParserInfo(): List<ParserInfo> = parsers.map {
+        ParserInfo(it.name, it.priority)
+    }
 
     /**
      * Internal data class for storing parser entries.
      */
-    private data class ParserEntry(
-        val parser: InformationModelParserStrategy,
-        val priority: Int,
-        val name: String,
-    )
+    private data class ParserEntry(val parser: InformationModelParserStrategy, val priority: Int, val name: String)
 
     /**
      * Data class for parser information.
      */
-    data class ParserInfo(
-        val name: String,
-        val priority: Int,
-    )
+    data class ParserInfo(val name: String, val priority: Int)
 }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/RdfParserStrategy.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/RdfParserStrategy.kt
@@ -30,10 +30,7 @@ interface RdfParserStrategy<T> {
      * @throws IllegalArgumentException if the model is null or invalid
      * @throws UnsupportedOperationException if the model format is not supported
      */
-    fun parse(
-        model: Model,
-        iri: String,
-    ): T
+    fun parse(model: Model, iri: String): T
 
     /**
      * Parses an RDF model into a domain object of type T.
@@ -45,11 +42,7 @@ interface RdfParserStrategy<T> {
      * @throws IllegalArgumentException if the model is null or invalid
      * @throws UnsupportedOperationException if the model format is not supported
      */
-    fun parse(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): T
+    fun parse(model: Model, iri: String, fdkId: String): T
 }
 
 /**

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/ServiceParserRegistry.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/ServiceParserRegistry.kt
@@ -30,11 +30,7 @@ class ServiceParserRegistry {
      * @param priority The priority level (higher = more priority)
      * @param name Human-readable name for logging
      */
-    fun registerParser(
-        parser: ServiceParserStrategy,
-        priority: Int,
-        name: String,
-    ) {
+    fun registerParser(parser: ServiceParserStrategy, priority: Int, name: String) {
         parsers.add(ParserEntry(parser, priority, name))
         parsers.sortByDescending { it.priority }
         LOGGER.info("Registered service parser '$name' with priority $priority")
@@ -48,11 +44,7 @@ class ServiceParserRegistry {
      * @param fdkId The FDK ID of the resource
      * @return List of successfully parsed services in priority order
      */
-    fun parseWithAllParsers(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): List<Service> {
+    fun parseWithAllParsers(model: Model, iri: String, fdkId: String): List<Service> {
         val results = mutableListOf<Service>()
 
         for (entry in parsers) {
@@ -83,25 +75,17 @@ class ServiceParserRegistry {
     /**
      * Gets information about registered parsers.
      */
-    fun getParserInfo(): List<ParserInfo> =
-        parsers.map {
-            ParserInfo(it.name, it.priority)
-        }
+    fun getParserInfo(): List<ParserInfo> = parsers.map {
+        ParserInfo(it.name, it.priority)
+    }
 
     /**
      * Internal data class for storing parser entries.
      */
-    private data class ParserEntry(
-        val parser: ServiceParserStrategy,
-        val priority: Int,
-        val name: String,
-    )
+    private data class ParserEntry(val parser: ServiceParserStrategy, val priority: Int, val name: String)
 
     /**
      * Data class for parser information.
      */
-    data class ParserInfo(
-        val name: String,
-        val priority: Int,
-    )
+    data class ParserInfo(val name: String, val priority: Int)
 }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/concept/SkosApNoV1Parser.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/concept/SkosApNoV1Parser.kt
@@ -51,16 +51,9 @@ class SkosApNoV1Parser : BaseConceptParser() {
 
     private fun getAcceptableTypes(): List<Resource> = listOf(SKOS.Concept)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-    ): Concept = parseConcept(model, iri, null)
+    override fun parse(model: Model, iri: String): Concept = parseConcept(model, iri, null)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): Concept = parseConcept(model, iri, fdkId)
+    override fun parse(model: Model, iri: String, fdkId: String): Concept = parseConcept(model, iri, fdkId)
 
     /**
      * Parses an RDF model into a Concept object according to SKOS-AP-NO v1.1.1.
@@ -75,11 +68,7 @@ class SkosApNoV1Parser : BaseConceptParser() {
      * @throws IllegalArgumentException if the model is null or invalid
      * @throws UnsupportedOperationException if no valid FDK record is found
      */
-    private fun parseConcept(
-        model: Model,
-        iri: String,
-        fdkId: String?,
-    ): Concept {
+    private fun parseConcept(model: Model, iri: String, fdkId: String?): Concept {
         val acceptableTypes = getAcceptableTypes()
         if (acceptableTypes.none { model.containsTriple(iri, RDF.type.uri, URI.create(it.uri)) }) {
             throw NoAcceptableTypesException("No acceptable types found for $iri")

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/concept/SkosApNoV2Parser.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/concept/SkosApNoV2Parser.kt
@@ -55,16 +55,9 @@ class SkosApNoV2Parser : BaseConceptParser() {
 
     private fun getAcceptableTypes(): List<Resource> = listOf(SKOS.Concept)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-    ): Concept = parseConcept(model, iri, null)
+    override fun parse(model: Model, iri: String): Concept = parseConcept(model, iri, null)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): Concept = parseConcept(model, iri, fdkId)
+    override fun parse(model: Model, iri: String, fdkId: String): Concept = parseConcept(model, iri, fdkId)
 
     /**
      * Parses an RDF model into a Concept object according to SKOS-AP-NO.
@@ -79,11 +72,7 @@ class SkosApNoV2Parser : BaseConceptParser() {
      * @throws IllegalArgumentException if the model is null or invalid
      * @throws UnsupportedOperationException if no valid FDK record is found
      */
-    private fun parseConcept(
-        model: Model,
-        iri: String,
-        fdkId: String?,
-    ): Concept {
+    private fun parseConcept(model: Model, iri: String, fdkId: String?): Concept {
         val acceptableTypes = getAcceptableTypes()
         if (acceptableTypes.none { model.containsTriple(iri, RDF.type.uri, URI.create(it.uri)) }) {
             throw NoAcceptableTypesException("No acceptable types found for $iri")

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/dataservice/DcatApNoV2Parser.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/dataservice/DcatApNoV2Parser.kt
@@ -61,16 +61,9 @@ class DcatApNoV2Parser : BaseDataServiceParser() {
 
     override fun getAcceptableTypes(): List<Resource> = listOf(DCAT.DataService)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-    ): DataService = parseDataService(model, iri, null)
+    override fun parse(model: Model, iri: String): DataService = parseDataService(model, iri, null)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): DataService = parseDataService(model, iri, fdkId)
+    override fun parse(model: Model, iri: String, fdkId: String): DataService = parseDataService(model, iri, fdkId)
 
     /**
      * Parses an RDF model into a DataService object according to DCAT-AP-NO v2.2.
@@ -85,11 +78,7 @@ class DcatApNoV2Parser : BaseDataServiceParser() {
      * @throws IllegalArgumentException if the model is null or invalid
      * @throws UnsupportedOperationException if no valid FDK record is found
      */
-    private fun parseDataService(
-        model: Model,
-        iri: String,
-        fdkId: String?,
-    ): DataService {
+    private fun parseDataService(model: Model, iri: String, fdkId: String?): DataService {
         if (getAcceptableTypes().none { model.containsTriple(iri, RDF.type.uri, URI.create(it.uri)) }) {
             throw NoAcceptableTypesException("No acceptable types found for $iri")
         }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/dataset/DcatApNoV1Parser.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/dataset/DcatApNoV1Parser.kt
@@ -67,16 +67,9 @@ class DcatApNoV1Parser : BaseDatasetParser() {
 
     override fun getAcceptableTypes(): List<Resource> = listOf(DCAT.Dataset)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-    ): Dataset = parseDataset(model, iri, null)
+    override fun parse(model: Model, iri: String): Dataset = parseDataset(model, iri, null)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): Dataset = parseDataset(model, iri, fdkId)
+    override fun parse(model: Model, iri: String, fdkId: String): Dataset = parseDataset(model, iri, fdkId)
 
     /**
      * Parses an RDF model into a Dataset object according to DCAT-AP-NO v1.1.
@@ -90,11 +83,7 @@ class DcatApNoV1Parser : BaseDatasetParser() {
      * @throws IllegalArgumentException if the model is null or invalid
      * @throws UnsupportedOperationException if no valid FDK record is found
      */
-    private fun parseDataset(
-        model: Model,
-        iri: String,
-        fdkId: String?,
-    ): Dataset {
+    private fun parseDataset(model: Model, iri: String, fdkId: String?): Dataset {
         if (getAcceptableTypes().none { model.containsTriple(iri, RDF.type.uri, URI.create(it.uri)) }) {
             throw NoAcceptableTypesException("No acceptable types found for $iri")
         }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/dataset/DcatApNoV2Parser.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/dataset/DcatApNoV2Parser.kt
@@ -76,16 +76,9 @@ class DcatApNoV2Parser : BaseDatasetParser() {
 
     override fun getAcceptableTypes(): List<Resource> = listOf(DCAT.Dataset, DCAT3.DatasetSeries)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-    ): Dataset = parseDataset(model, iri, null)
+    override fun parse(model: Model, iri: String): Dataset = parseDataset(model, iri, null)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): Dataset = parseDataset(model, iri, fdkId)
+    override fun parse(model: Model, iri: String, fdkId: String): Dataset = parseDataset(model, iri, fdkId)
 
     /**
      * Parses an RDF model into a Dataset object according to DCAT-AP-NO v2.2.
@@ -100,11 +93,7 @@ class DcatApNoV2Parser : BaseDatasetParser() {
      * @throws IllegalArgumentException if the model is null or invalid
      * @throws UnsupportedOperationException if no valid FDK record is found
      */
-    private fun parseDataset(
-        model: Model,
-        iri: String,
-        fdkId: String?,
-    ): Dataset {
+    private fun parseDataset(model: Model, iri: String, fdkId: String?): Dataset {
         if (getAcceptableTypes().none { model.containsTriple(iri, RDF.type.uri, URI.create(it.uri)) }) {
             throw NoAcceptableTypesException("No acceptable types found for $iri")
         }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/dataset/DcatApNoV3Parser.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/dataset/DcatApNoV3Parser.kt
@@ -48,16 +48,9 @@ class DcatApNoV3Parser : BaseDatasetParser() {
 
     override fun getAcceptableTypes(): List<Resource> = listOf(DCAT.Dataset, DCAT3.DatasetSeries)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-    ): Dataset = parseDataset(model, iri, null)
+    override fun parse(model: Model, iri: String): Dataset = parseDataset(model, iri, null)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): Dataset = parseDataset(model, iri, fdkId)
+    override fun parse(model: Model, iri: String, fdkId: String): Dataset = parseDataset(model, iri, fdkId)
 
     /**
      * Parses an RDF model into a Dataset object according to DCAT-AP-NO v3.
@@ -72,11 +65,7 @@ class DcatApNoV3Parser : BaseDatasetParser() {
      * @throws IllegalArgumentException if the model is null or invalid
      * @throws UnsupportedOperationException if no valid FDK record is found
      */
-    private fun parseDataset(
-        model: Model,
-        iri: String,
-        fdkId: String?,
-    ): Dataset {
+    private fun parseDataset(model: Model, iri: String, fdkId: String?): Dataset {
         if (getAcceptableTypes().none { model.containsTriple(iri, RDF.type.uri, URI.create(it.uri)) }) {
             throw NoAcceptableTypesException("No acceptable types found for $iri")
         }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/dataset/HvdDcatApNoParser.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/dataset/HvdDcatApNoParser.kt
@@ -48,16 +48,9 @@ class HvdDcatApNoParser : BaseDatasetParser() {
 
     override fun getAcceptableTypes(): List<Resource> = listOf(DCAT.Dataset, DCAT3.DatasetSeries)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-    ): Dataset = parseDataset(model, iri, null)
+    override fun parse(model: Model, iri: String): Dataset = parseDataset(model, iri, null)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): Dataset = parseDataset(model, iri, fdkId)
+    override fun parse(model: Model, iri: String, fdkId: String): Dataset = parseDataset(model, iri, fdkId)
 
     /**
      * Parses an RDF model into a Dataset object according to HVD-DCAT-AP-NO.
@@ -71,11 +64,7 @@ class HvdDcatApNoParser : BaseDatasetParser() {
      * @throws NoAcceptableTypesException if the resource is not a dataset or dataset series
      * @throws IllegalArgumentException if the model is null or invalid
      */
-    private fun parseDataset(
-        model: Model,
-        iri: String,
-        fdkId: String?,
-    ): Dataset {
+    private fun parseDataset(model: Model, iri: String, fdkId: String?): Dataset {
         if (getAcceptableTypes().none { model.containsTriple(iri, RDF.type.uri, URI.create(it.uri)) }) {
             throw NoAcceptableTypesException("No acceptable types found for $iri")
         }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/dataset/MobilityDcatApV3Parser.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/dataset/MobilityDcatApV3Parser.kt
@@ -65,16 +65,9 @@ class MobilityDcatApV3Parser : BaseDatasetParser() {
 
     override fun getAcceptableTypes(): List<Resource> = listOf(DCAT.Dataset)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-    ): Dataset = parseDataset(model, iri, null)
+    override fun parse(model: Model, iri: String): Dataset = parseDataset(model, iri, null)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): Dataset = parseDataset(model, iri, fdkId)
+    override fun parse(model: Model, iri: String, fdkId: String): Dataset = parseDataset(model, iri, fdkId)
 
     /**
      * Parses an RDF model into a Dataset object according to Mobility DCAT-AP v3.0.0.
@@ -90,11 +83,7 @@ class MobilityDcatApV3Parser : BaseDatasetParser() {
      * @throws IllegalArgumentException if the model is null or invalid
      * @throws UnsupportedOperationException if no valid FDK record is found
      */
-    private fun parseDataset(
-        model: Model,
-        iri: String,
-        fdkId: String?,
-    ): Dataset {
+    private fun parseDataset(model: Model, iri: String, fdkId: String?): Dataset {
         if (getAcceptableTypes().none { model.containsTriple(iri, RDF.type.uri, URI.create(it.uri)) }) {
             throw NoAcceptableTypesException("No acceptable types found for $iri")
         }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/event/CpsvApNoV0Parser.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/event/CpsvApNoV0Parser.kt
@@ -40,23 +40,15 @@ class CpsvApNoV0Parser : BaseEventParser() {
 
     override fun getSourceFormat(): String = "CPSV-AP-NO"
 
-    override fun getAcceptableTypes(): List<Resource> =
-        listOf(
-            ResourceFactory.createResource(CV.Event.uri),
-            ResourceFactory.createResource(CV.BusinessEvent.uri),
-            ResourceFactory.createResource(CV.LifeEvent.uri),
-        )
+    override fun getAcceptableTypes(): List<Resource> = listOf(
+        ResourceFactory.createResource(CV.Event.uri),
+        ResourceFactory.createResource(CV.BusinessEvent.uri),
+        ResourceFactory.createResource(CV.LifeEvent.uri),
+    )
 
-    override fun parse(
-        model: Model,
-        iri: String,
-    ): Event = parseEvent(model, iri, null)
+    override fun parse(model: Model, iri: String): Event = parseEvent(model, iri, null)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): Event = parseEvent(model, iri, fdkId)
+    override fun parse(model: Model, iri: String, fdkId: String): Event = parseEvent(model, iri, fdkId)
 
     /**
      * Parses an RDF model into an Event object according to CPSVNO.
@@ -71,11 +63,7 @@ class CpsvApNoV0Parser : BaseEventParser() {
      * @throws IllegalArgumentException if the model is null or invalid
      * @throws UnsupportedOperationException if no valid FDK record is found
      */
-    private fun parseEvent(
-        model: Model,
-        iri: String,
-        fdkId: String?,
-    ): Event {
+    private fun parseEvent(model: Model, iri: String, fdkId: String?): Event {
         val acceptableTypes = getAcceptableTypes()
         if (acceptableTypes.none { model.containsTriple(iri, RDF.type.uri, URI.create(it.uri)) }) {
             throw NoAcceptableTypesException("No acceptable types found for $iri")

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/event/CpsvApNoV1Parser.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/event/CpsvApNoV1Parser.kt
@@ -37,23 +37,15 @@ class CpsvApNoV1Parser : BaseEventParser() {
 
     override fun getSourceFormat(): String = "CPSV-AP-NO"
 
-    override fun getAcceptableTypes(): List<Resource> =
-        listOf(
-            ResourceFactory.createResource(CV.Event.uri),
-            ResourceFactory.createResource(CV.BusinessEvent.uri),
-            ResourceFactory.createResource(CV.LifeEvent.uri),
-        )
+    override fun getAcceptableTypes(): List<Resource> = listOf(
+        ResourceFactory.createResource(CV.Event.uri),
+        ResourceFactory.createResource(CV.BusinessEvent.uri),
+        ResourceFactory.createResource(CV.LifeEvent.uri),
+    )
 
-    override fun parse(
-        model: Model,
-        iri: String,
-    ): Event = parseEvent(model, iri, null)
+    override fun parse(model: Model, iri: String): Event = parseEvent(model, iri, null)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): Event = parseEvent(model, iri, fdkId)
+    override fun parse(model: Model, iri: String, fdkId: String): Event = parseEvent(model, iri, fdkId)
 
     /**
      * Parses an RDF model into an Event object according to CPSVNO version 1.1.2.
@@ -68,11 +60,7 @@ class CpsvApNoV1Parser : BaseEventParser() {
      * @throws IllegalArgumentException if the model is null or invalid
      * @throws UnsupportedOperationException if no valid FDK record is found
      */
-    private fun parseEvent(
-        model: Model,
-        iri: String,
-        fdkId: String?,
-    ): Event {
+    private fun parseEvent(model: Model, iri: String, fdkId: String?): Event {
         val acceptableTypes = getAcceptableTypes()
         if (acceptableTypes.none { model.containsTriple(iri, RDF.type.uri, URI.create(it.uri)) }) {
             throw NoAcceptableTypesException("No acceptable types found for $iri")

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/informationmodel/ModellDcatApNoV1Parser.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/informationmodel/ModellDcatApNoV1Parser.kt
@@ -67,16 +67,9 @@ class ModellDcatApNoV1Parser : BaseInformationModelParser() {
 
     override fun getAcceptableTypes(): List<Resource> = listOf(MODELLDCATNO.InformationModel)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-    ): InformationModel = parseInformationModel(model, iri, null)
+    override fun parse(model: Model, iri: String): InformationModel = parseInformationModel(model, iri, null)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): InformationModel = parseInformationModel(model, iri, fdkId)
+    override fun parse(model: Model, iri: String, fdkId: String): InformationModel = parseInformationModel(model, iri, fdkId)
 
     private data class ParseContext(
         val modelElements: MutableMap<CharSequence, InformationModelElement> = mutableMapOf(),
@@ -97,11 +90,7 @@ class ModellDcatApNoV1Parser : BaseInformationModelParser() {
      * @throws IllegalArgumentException if the model is null or invalid
      * @throws UnsupportedOperationException if no valid FDK record is found
      */
-    private fun parseInformationModel(
-        model: Model,
-        iri: String,
-        fdkId: String?,
-    ): InformationModel {
+    private fun parseInformationModel(model: Model, iri: String, fdkId: String?): InformationModel {
         if (getAcceptableTypes().none { model.containsTriple(iri, RDF.type.uri, URI.create(it.uri)) }) {
             throw NoAcceptableTypesException("No acceptable types found for $iri")
         }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/service/CpsvApNoV0Parser.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/service/CpsvApNoV0Parser.kt
@@ -42,24 +42,16 @@ class CpsvApNoV0Parser : BaseServiceParser() {
 
     override fun getSourceFormat(): String = "CPSV-AP-NO"
 
-    override fun getAcceptableTypes(): List<Resource> =
-        listOf(
-            org.apache.jena.rdf.model.ResourceFactory
-                .createResource(CPSVNO.Service.uri),
-            org.apache.jena.rdf.model.ResourceFactory
-                .createResource(CPSV.PublicService.uri),
-        )
+    override fun getAcceptableTypes(): List<Resource> = listOf(
+        org.apache.jena.rdf.model.ResourceFactory
+            .createResource(CPSVNO.Service.uri),
+        org.apache.jena.rdf.model.ResourceFactory
+            .createResource(CPSV.PublicService.uri),
+    )
 
-    override fun parse(
-        model: Model,
-        iri: String,
-    ): Service = parseService(model, iri, null)
+    override fun parse(model: Model, iri: String): Service = parseService(model, iri, null)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): Service = parseService(model, iri, fdkId)
+    override fun parse(model: Model, iri: String, fdkId: String): Service = parseService(model, iri, fdkId)
 
     /**
      * Parses an RDF model into a Service object according to CPSVNO.
@@ -74,11 +66,7 @@ class CpsvApNoV0Parser : BaseServiceParser() {
      * @throws IllegalArgumentException if the model is null or invalid
      * @throws UnsupportedOperationException if no valid FDK record is found
      */
-    private fun parseService(
-        model: Model,
-        iri: String,
-        fdkId: String?,
-    ): Service {
+    private fun parseService(model: Model, iri: String, fdkId: String?): Service {
         val acceptableTypes = getAcceptableTypes()
         if (acceptableTypes.none { model.containsTriple(iri, RDF.type.uri, URI.create(it.uri)) }) {
             throw NoAcceptableTypesException("No acceptable types found for $iri")

--- a/src/main/kotlin/no/digdir/fdk/parserservice/parser/service/CpsvApNoV1Parser.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/parser/service/CpsvApNoV1Parser.kt
@@ -45,24 +45,16 @@ class CpsvApNoV1Parser : BaseServiceParser() {
 
     override fun getSourceFormat(): String = "CPSV-AP-NO"
 
-    override fun getAcceptableTypes(): List<Resource> =
-        listOf(
-            ResourceFactory
-                .createResource(CPSVNO.Service.uri),
-            ResourceFactory
-                .createResource(CPSV.PublicService.uri),
-        )
+    override fun getAcceptableTypes(): List<Resource> = listOf(
+        ResourceFactory
+            .createResource(CPSVNO.Service.uri),
+        ResourceFactory
+            .createResource(CPSV.PublicService.uri),
+    )
 
-    override fun parse(
-        model: Model,
-        iri: String,
-    ): Service = parseService(model, iri, null)
+    override fun parse(model: Model, iri: String): Service = parseService(model, iri, null)
 
-    override fun parse(
-        model: Model,
-        iri: String,
-        fdkId: String,
-    ): Service = parseService(model, iri, fdkId)
+    override fun parse(model: Model, iri: String, fdkId: String): Service = parseService(model, iri, fdkId)
 
     /**
      * Parses an RDF model into a Service object according to CPSVNO.
@@ -77,11 +69,7 @@ class CpsvApNoV1Parser : BaseServiceParser() {
      * @throws IllegalArgumentException if the model is null or invalid
      * @throws UnsupportedOperationException if no valid FDK record is found
      */
-    private fun parseService(
-        model: Model,
-        iri: String,
-        fdkId: String?,
-    ): Service {
+    private fun parseService(model: Model, iri: String, fdkId: String?): Service {
         val acceptableTypes = getAcceptableTypes()
         if (acceptableTypes.none { model.containsTriple(iri, RDF.type.uri, URI.create(it.uri)) }) {
             throw NoAcceptableTypesException("No acceptable types found for $iri")

--- a/src/main/kotlin/no/digdir/fdk/parserservice/utils/ConceptMerger.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/utils/ConceptMerger.kt
@@ -67,8 +67,5 @@ object ConceptMerger {
      * @param fallbacks Additional concepts in priority order
      * @return A new Concept with values from the highest priority non-null source
      */
-    fun merge(
-        prioritized: Concept,
-        vararg fallbacks: Concept,
-    ): Concept = merge(listOf(prioritized) + fallbacks)
+    fun merge(prioritized: Concept, vararg fallbacks: Concept): Concept = merge(listOf(prioritized) + fallbacks)
 }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/utils/DatasetMerger.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/utils/DatasetMerger.kt
@@ -91,8 +91,5 @@ object DatasetMerger {
      * @param fallbacks Additional datasets in priority order
      * @return A new Dataset with values from the highest priority non-null source
      */
-    fun merge(
-        prioritized: Dataset,
-        vararg fallbacks: Dataset,
-    ): Dataset = merge(listOf(prioritized) + fallbacks)
+    fun merge(prioritized: Dataset, vararg fallbacks: Dataset): Dataset = merge(listOf(prioritized) + fallbacks)
 }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/utils/EventMerger.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/utils/EventMerger.kt
@@ -41,8 +41,5 @@ object EventMerger {
     /**
      * Convenience overload for merging a prioritized event with fallback events.
      */
-    fun merge(
-        prioritized: Event,
-        vararg fallbacks: Event,
-    ): Event = merge(listOf(prioritized) + fallbacks)
+    fun merge(prioritized: Event, vararg fallbacks: Event): Event = merge(listOf(prioritized) + fallbacks)
 }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/utils/ServiceMerger.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/utils/ServiceMerger.kt
@@ -66,8 +66,5 @@ object ServiceMerger {
     /**
      * Convenience overload for merging a prioritized service with fallback services.
      */
-    fun merge(
-        prioritized: Service,
-        vararg fallbacks: Service,
-    ): Service = merge(listOf(prioritized) + fallbacks)
+    fun merge(prioritized: Service, vararg fallbacks: Service): Service = merge(listOf(prioritized) + fallbacks)
 }

--- a/src/main/kotlin/no/digdir/fdk/parserservice/utils/Utils.kt
+++ b/src/main/kotlin/no/digdir/fdk/parserservice/utils/Utils.kt
@@ -53,10 +53,7 @@ fun Model.readTurtle(turtleGraph: String) {
  * @throws Exception if serialization fails
  * @see FlatteningJsonEncoder
  */
-inline fun <reified T> avroToJson(
-    avroObject: T,
-    schema: Schema,
-): JsonNode {
+inline fun <reified T> avroToJson(avroObject: T, schema: Schema): JsonNode {
     val mapper = jacksonObjectMapper()
     val outputStream = ByteArrayOutputStream()
     val datumWriter: DatumWriter<T> = SpecificDatumWriter(schema)

--- a/src/test/kotlin/no/digdir/fdk/parserservice/handler/DatasetHandlerTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/parserservice/handler/DatasetHandlerTest.kt
@@ -377,38 +377,24 @@ class DatasetHandlerTest {
 
         val mobility =
             object : DatasetParserStrategy {
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                ) = Dataset().apply {
+                override fun parse(model: Model, iri: String) = Dataset().apply {
                     id = "id"
                     uri = iri
                     title = LocalizedStrings().apply { en = "MOB" }
                 }
 
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                    fdkId: String,
-                ) = parse(model, iri)
+                override fun parse(model: Model, iri: String, fdkId: String) = parse(model, iri)
             }
 
         val v2 =
             object : DatasetParserStrategy {
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                ) = Dataset().apply {
+                override fun parse(model: Model, iri: String) = Dataset().apply {
                     id = "id"
                     uri = iri
                     title = LocalizedStrings().apply { en = "V2" }
                 }
 
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                    fdkId: String,
-                ) = parse(model, iri)
+                override fun parse(model: Model, iri: String, fdkId: String) = parse(model, iri)
             }
 
         localRegistry.registerParser(mobility, 200, "mob")

--- a/src/test/kotlin/no/digdir/fdk/parserservice/parser/ConceptParserRegistryTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/parserservice/parser/ConceptParserRegistryTest.kt
@@ -14,14 +14,10 @@ import kotlin.test.assertTrue
  */
 @Tag("unit")
 class ConceptParserRegistryTest {
-    private fun minimalConcept(
-        id: String,
-        uri: String,
-    ): Concept =
-        Concept().apply {
-            this.id = id
-            this.uri = uri
-        }
+    private fun minimalConcept(id: String, uri: String): Concept = Concept().apply {
+        this.id = id
+        this.uri = uri
+    }
 
     @Test
     fun `should register parsers and execute in priority order`() {
@@ -69,16 +65,9 @@ class ConceptParserRegistryTest {
         // Create parsers where one fails
         val failingParser =
             object : ConceptParserStrategy {
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                ): Concept = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String): Concept = throw RuntimeException("Parser failed")
 
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                    fdkId: String,
-                ): Concept = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String, fdkId: String): Concept = throw RuntimeException("Parser failed")
             }
 
         val succeedingParser = createMockParser("success", 50)
@@ -99,16 +88,9 @@ class ConceptParserRegistryTest {
 
         val failingParser =
             object : ConceptParserStrategy {
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                ): Concept = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String): Concept = throw RuntimeException("Parser failed")
 
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                    fdkId: String,
-                ): Concept = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String, fdkId: String): Concept = throw RuntimeException("Parser failed")
             }
 
         registry.registerParser(failingParser, 100, "Failing Parser")
@@ -119,22 +101,11 @@ class ConceptParserRegistryTest {
         }
     }
 
-    private fun createMockParser(
-        id: String,
-        priority: Int,
-    ): ConceptParserStrategy =
-        object : ConceptParserStrategy {
-            override fun parse(
-                model: Model,
-                iri: String,
-            ): Concept = minimalConcept(id, iri)
+    private fun createMockParser(id: String, priority: Int): ConceptParserStrategy = object : ConceptParserStrategy {
+        override fun parse(model: Model, iri: String): Concept = minimalConcept(id, iri)
 
-            override fun parse(
-                model: Model,
-                iri: String,
-                fdkId: String,
-            ): Concept = minimalConcept(id, iri)
-        }
+        override fun parse(model: Model, iri: String, fdkId: String): Concept = minimalConcept(id, iri)
+    }
 
     @Test
     fun `results are returned in parser priority order`() {
@@ -142,29 +113,15 @@ class ConceptParserRegistryTest {
 
         val lowPriority =
             object : ConceptParserStrategy {
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                ): Concept = minimalConcept("LOW", iri)
+                override fun parse(model: Model, iri: String): Concept = minimalConcept("LOW", iri)
 
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                    fdkId: String,
-                ): Concept = minimalConcept("LOW", iri)
+                override fun parse(model: Model, iri: String, fdkId: String): Concept = minimalConcept("LOW", iri)
             }
         val highPriority =
             object : ConceptParserStrategy {
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                ): Concept = minimalConcept("HIGH", iri)
+                override fun parse(model: Model, iri: String): Concept = minimalConcept("HIGH", iri)
 
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                    fdkId: String,
-                ): Concept = minimalConcept("HIGH", iri)
+                override fun parse(model: Model, iri: String, fdkId: String): Concept = minimalConcept("HIGH", iri)
             }
 
         registry.registerParser(lowPriority, priority = 50, name = "low")

--- a/src/test/kotlin/no/digdir/fdk/parserservice/parser/DataServiceParserRegistryTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/parserservice/parser/DataServiceParserRegistryTest.kt
@@ -14,14 +14,10 @@ import kotlin.test.assertTrue
  */
 @Tag("unit")
 class DataServiceParserRegistryTest {
-    private fun minimalDataService(
-        id: String,
-        uri: String,
-    ): DataService =
-        DataService().apply {
-            this.id = id
-            this.uri = uri
-        }
+    private fun minimalDataService(id: String, uri: String): DataService = DataService().apply {
+        this.id = id
+        this.uri = uri
+    }
 
     @Test
     fun `should register parsers and execute in priority order`() {
@@ -69,16 +65,9 @@ class DataServiceParserRegistryTest {
         // Create parsers where one fails
         val failingParser =
             object : DataServiceParserStrategy {
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                ): DataService = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String): DataService = throw RuntimeException("Parser failed")
 
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                    fdkId: String,
-                ): DataService = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String, fdkId: String): DataService = throw RuntimeException("Parser failed")
             }
 
         val succeedingParser = createMockParser("success", 50)
@@ -99,16 +88,9 @@ class DataServiceParserRegistryTest {
 
         val failingParser =
             object : DataServiceParserStrategy {
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                ): DataService = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String): DataService = throw RuntimeException("Parser failed")
 
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                    fdkId: String,
-                ): DataService = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String, fdkId: String): DataService = throw RuntimeException("Parser failed")
             }
 
         registry.registerParser(failingParser, 100, "Failing Parser")
@@ -119,20 +101,9 @@ class DataServiceParserRegistryTest {
         }
     }
 
-    private fun createMockParser(
-        id: String,
-        priority: Int,
-    ): DataServiceParserStrategy =
-        object : DataServiceParserStrategy {
-            override fun parse(
-                model: Model,
-                iri: String,
-            ): DataService = minimalDataService(id, iri)
+    private fun createMockParser(id: String, priority: Int): DataServiceParserStrategy = object : DataServiceParserStrategy {
+        override fun parse(model: Model, iri: String): DataService = minimalDataService(id, iri)
 
-            override fun parse(
-                model: Model,
-                iri: String,
-                fdkId: String,
-            ): DataService = minimalDataService(id, iri)
-        }
+        override fun parse(model: Model, iri: String, fdkId: String): DataService = minimalDataService(id, iri)
+    }
 }

--- a/src/test/kotlin/no/digdir/fdk/parserservice/parser/DatasetParserRegistryTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/parserservice/parser/DatasetParserRegistryTest.kt
@@ -14,14 +14,10 @@ import kotlin.test.assertTrue
  */
 @Tag("unit")
 class DatasetParserRegistryTest {
-    private fun minimalDataset(
-        id: String,
-        uri: String,
-    ): Dataset =
-        Dataset().apply {
-            this.id = id
-            this.uri = uri
-        }
+    private fun minimalDataset(id: String, uri: String): Dataset = Dataset().apply {
+        this.id = id
+        this.uri = uri
+    }
 
     @Test
     fun `should register parsers and execute in priority order`() {
@@ -69,16 +65,9 @@ class DatasetParserRegistryTest {
         // Create parsers where one fails
         val failingParser =
             object : DatasetParserStrategy {
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                ): Dataset = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String): Dataset = throw RuntimeException("Parser failed")
 
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                    fdkId: String,
-                ): Dataset = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String, fdkId: String): Dataset = throw RuntimeException("Parser failed")
             }
 
         val succeedingParser = createMockParser("success", 50)
@@ -99,16 +88,9 @@ class DatasetParserRegistryTest {
 
         val failingParser =
             object : DatasetParserStrategy {
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                ): Dataset = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String): Dataset = throw RuntimeException("Parser failed")
 
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                    fdkId: String,
-                ): Dataset = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String, fdkId: String): Dataset = throw RuntimeException("Parser failed")
             }
 
         registry.registerParser(failingParser, 100, "Failing Parser")
@@ -119,22 +101,11 @@ class DatasetParserRegistryTest {
         }
     }
 
-    private fun createMockParser(
-        id: String,
-        priority: Int,
-    ): DatasetParserStrategy =
-        object : DatasetParserStrategy {
-            override fun parse(
-                model: Model,
-                iri: String,
-            ): Dataset = minimalDataset(id, iri)
+    private fun createMockParser(id: String, priority: Int): DatasetParserStrategy = object : DatasetParserStrategy {
+        override fun parse(model: Model, iri: String): Dataset = minimalDataset(id, iri)
 
-            override fun parse(
-                model: Model,
-                iri: String,
-                fdkId: String,
-            ): Dataset = minimalDataset(id, iri)
-        }
+        override fun parse(model: Model, iri: String, fdkId: String): Dataset = minimalDataset(id, iri)
+    }
 
     @Test
     fun `results are returned in parser priority order`() {
@@ -142,29 +113,15 @@ class DatasetParserRegistryTest {
 
         val lowPriority =
             object : DatasetParserStrategy {
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                ): Dataset = minimalDataset("LOW", iri)
+                override fun parse(model: Model, iri: String): Dataset = minimalDataset("LOW", iri)
 
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                    fdkId: String,
-                ): Dataset = minimalDataset("LOW", iri)
+                override fun parse(model: Model, iri: String, fdkId: String): Dataset = minimalDataset("LOW", iri)
             }
         val highPriority =
             object : DatasetParserStrategy {
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                ): Dataset = minimalDataset("HIGH", iri)
+                override fun parse(model: Model, iri: String): Dataset = minimalDataset("HIGH", iri)
 
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                    fdkId: String,
-                ): Dataset = minimalDataset("HIGH", iri)
+                override fun parse(model: Model, iri: String, fdkId: String): Dataset = minimalDataset("HIGH", iri)
             }
 
         registry.registerParser(lowPriority, priority = 50, name = "low")

--- a/src/test/kotlin/no/digdir/fdk/parserservice/parser/EventParserRegistryTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/parserservice/parser/EventParserRegistryTest.kt
@@ -60,16 +60,9 @@ class EventParserRegistryTest {
         // Create parsers where one fails
         val failingParser =
             object : EventParserStrategy {
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                ): Event = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String): Event = throw RuntimeException("Parser failed")
 
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                    fdkId: String,
-                ): Event = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String, fdkId: String): Event = throw RuntimeException("Parser failed")
             }
 
         val succeedingParser = createMockParser("success", 50)
@@ -90,16 +83,9 @@ class EventParserRegistryTest {
 
         val failingParser =
             object : EventParserStrategy {
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                ): Event = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String): Event = throw RuntimeException("Parser failed")
 
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                    fdkId: String,
-                ): Event = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String, fdkId: String): Event = throw RuntimeException("Parser failed")
             }
 
         registry.registerParser(failingParser, 100, "Failing Parser")
@@ -110,28 +96,15 @@ class EventParserRegistryTest {
         }
     }
 
-    private fun createMockParser(
-        eventId: String,
-        priority: Int,
-    ): EventParserStrategy =
-        object : EventParserStrategy {
-            override fun parse(
-                model: Model,
-                iri: String,
-            ): Event =
-                Event().apply {
-                    id = eventId
-                    uri = iri
-                }
-
-            override fun parse(
-                model: Model,
-                iri: String,
-                fdkId: String,
-            ): Event =
-                Event().apply {
-                    id = eventId
-                    uri = iri
-                }
+    private fun createMockParser(eventId: String, priority: Int): EventParserStrategy = object : EventParserStrategy {
+        override fun parse(model: Model, iri: String): Event = Event().apply {
+            id = eventId
+            uri = iri
         }
+
+        override fun parse(model: Model, iri: String, fdkId: String): Event = Event().apply {
+            id = eventId
+            uri = iri
+        }
+    }
 }

--- a/src/test/kotlin/no/digdir/fdk/parserservice/parser/InformationModelParserRegistryTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/parserservice/parser/InformationModelParserRegistryTest.kt
@@ -11,14 +11,10 @@ import kotlin.test.assertTrue
 
 @Tag("unit")
 class InformationModelParserRegistryTest {
-    private fun minimalInformationModel(
-        id: String,
-        uri: String,
-    ): InformationModel =
-        InformationModel().apply {
-            this.id = id
-            this.uri = uri
-        }
+    private fun minimalInformationModel(id: String, uri: String): InformationModel = InformationModel().apply {
+        this.id = id
+        this.uri = uri
+    }
 
     @Test
     fun `should register parsers and execute in priority order`() {
@@ -61,16 +57,9 @@ class InformationModelParserRegistryTest {
 
         val failingParser =
             object : InformationModelParserStrategy {
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                ): InformationModel = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String): InformationModel = throw RuntimeException("Parser failed")
 
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                    fdkId: String,
-                ): InformationModel = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String, fdkId: String): InformationModel = throw RuntimeException("Parser failed")
             }
 
         val succeedingParser = createMockParser("success", 50)
@@ -91,16 +80,9 @@ class InformationModelParserRegistryTest {
 
         val failingParser =
             object : InformationModelParserStrategy {
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                ): InformationModel = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String): InformationModel = throw RuntimeException("Parser failed")
 
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                    fdkId: String,
-                ): InformationModel = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String, fdkId: String): InformationModel = throw RuntimeException("Parser failed")
             }
 
         registry.registerParser(failingParser, 100, "Failing Parser")
@@ -111,20 +93,9 @@ class InformationModelParserRegistryTest {
         }
     }
 
-    private fun createMockParser(
-        id: String,
-        priority: Int,
-    ): InformationModelParserStrategy =
-        object : InformationModelParserStrategy {
-            override fun parse(
-                model: Model,
-                iri: String,
-            ): InformationModel = minimalInformationModel(id, iri)
+    private fun createMockParser(id: String, priority: Int): InformationModelParserStrategy = object : InformationModelParserStrategy {
+        override fun parse(model: Model, iri: String): InformationModel = minimalInformationModel(id, iri)
 
-            override fun parse(
-                model: Model,
-                iri: String,
-                fdkId: String,
-            ): InformationModel = minimalInformationModel(id, iri)
-        }
+        override fun parse(model: Model, iri: String, fdkId: String): InformationModel = minimalInformationModel(id, iri)
+    }
 }

--- a/src/test/kotlin/no/digdir/fdk/parserservice/parser/ServiceParserRegistryTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/parserservice/parser/ServiceParserRegistryTest.kt
@@ -60,16 +60,9 @@ class ServiceParserRegistryTest {
         // Create parsers where one fails
         val failingParser =
             object : ServiceParserStrategy {
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                ): Service = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String): Service = throw RuntimeException("Parser failed")
 
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                    fdkId: String,
-                ): Service = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String, fdkId: String): Service = throw RuntimeException("Parser failed")
             }
 
         val succeedingParser = createMockParser("success", 50)
@@ -90,16 +83,9 @@ class ServiceParserRegistryTest {
 
         val failingParser =
             object : ServiceParserStrategy {
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                ): Service = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String): Service = throw RuntimeException("Parser failed")
 
-                override fun parse(
-                    model: Model,
-                    iri: String,
-                    fdkId: String,
-                ): Service = throw RuntimeException("Parser failed")
+                override fun parse(model: Model, iri: String, fdkId: String): Service = throw RuntimeException("Parser failed")
             }
 
         registry.registerParser(failingParser, 100, "Failing Parser")
@@ -110,28 +96,15 @@ class ServiceParserRegistryTest {
         }
     }
 
-    private fun createMockParser(
-        serviceId: String,
-        priority: Int,
-    ): ServiceParserStrategy =
-        object : ServiceParserStrategy {
-            override fun parse(
-                model: Model,
-                iri: String,
-            ): Service =
-                Service().apply {
-                    id = serviceId
-                    uri = iri
-                }
-
-            override fun parse(
-                model: Model,
-                iri: String,
-                fdkId: String,
-            ): Service =
-                Service().apply {
-                    id = serviceId
-                    uri = iri
-                }
+    private fun createMockParser(serviceId: String, priority: Int): ServiceParserStrategy = object : ServiceParserStrategy {
+        override fun parse(model: Model, iri: String): Service = Service().apply {
+            id = serviceId
+            uri = iri
         }
+
+        override fun parse(model: Model, iri: String, fdkId: String): Service = Service().apply {
+            id = serviceId
+            uri = iri
+        }
+    }
 }

--- a/src/test/kotlin/no/digdir/fdk/parserservice/utils/ConceptMergerTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/parserservice/utils/ConceptMergerTest.kt
@@ -18,14 +18,10 @@ import kotlin.test.assertEquals
 
 @Tag("unit")
 class ConceptMergerTest {
-    private fun minimal(
-        id: String,
-        uri: String,
-    ): Concept =
-        Concept().apply {
-            this.id = id
-            this.uri = uri
-        }
+    private fun minimal(id: String, uri: String): Concept = Concept().apply {
+        this.id = id
+        this.uri = uri
+    }
 
     @Test
     fun `should merge concepts with priority order`() {

--- a/src/test/kotlin/no/digdir/fdk/parserservice/utils/DatasetMergerTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/parserservice/utils/DatasetMergerTest.kt
@@ -9,14 +9,10 @@ import kotlin.test.assertEquals
 
 @Tag("unit")
 class DatasetMergerTest {
-    private fun minimal(
-        id: String,
-        uri: String,
-    ): Dataset =
-        Dataset().apply {
-            this.id = id
-            this.uri = uri
-        }
+    private fun minimal(id: String, uri: String): Dataset = Dataset().apply {
+        this.id = id
+        this.uri = uri
+    }
 
     @Test
     fun `should merge datasets with priority order`() {

--- a/src/test/kotlin/no/digdir/fdk/parserservice/utils/EventMergerTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/parserservice/utils/EventMergerTest.kt
@@ -11,14 +11,10 @@ import kotlin.test.assertEquals
 
 @Tag("unit")
 class EventMergerTest {
-    private fun minimal(
-        id: String,
-        uri: String,
-    ): Event =
-        Event().apply {
-            this.id = id
-            this.uri = uri
-        }
+    private fun minimal(id: String, uri: String): Event = Event().apply {
+        this.id = id
+        this.uri = uri
+    }
 
     @Test
     fun `should merge events with priority order`() {

--- a/src/test/kotlin/no/digdir/fdk/parserservice/utils/ServiceMergerTest.kt
+++ b/src/test/kotlin/no/digdir/fdk/parserservice/utils/ServiceMergerTest.kt
@@ -11,14 +11,10 @@ import kotlin.test.assertEquals
 
 @Tag("unit")
 class ServiceMergerTest {
-    private fun minimal(
-        id: String,
-        uri: String,
-    ): Service =
-        Service().apply {
-            this.id = id
-            this.uri = uri
-        }
+    private fun minimal(id: String, uri: String): Service = Service().apply {
+        this.id = id
+        this.uri = uri
+    }
 
     @Test
     fun `should merge services with priority order`() {


### PR DESCRIPTION
# Summary 

- Bumps `spring-boot-starter-parent` from 4.0.6 to 4.1.0, pulling in Tomcat 11.0.22 which fixes three critical authentication-bypass CVEs.
- Also brings Spring Framework 7.0.8, Jackson 2.21.4 / 3.1.4 and spring-data-commons 4.1.0. No code changes were needed; the project has no OAuth2 resource server config and no PostgreSQL dependency, so the known 4.1.0 breaking changes do not apply here.
- Unlike the sibling services, ktlint here is **not** a no-op: this pom sets `sourceDirectory`/`testSourceDirectory` to `src/main/kotlin` and `src/test/kotlin`, so ktlint already inspects all 118 main and 52 test Kotlin files. Verified by injecting a deliberately misformatted function and confirming ktlint rewrote it, and a naming violation and confirming `ktlint:check` failed the build.
- Adds a comment above the ktlint plugin recording that dependency, so a future edit to `sourceDirectory` cannot silently degrade ktlint into inspecting no files while still reporting green.
- Adds `.editorconfig` pinning `max_line_length = 140` for Kotlin (previously only an implicit ktlint default) plus charset, line endings and indentation for the other file types. Zero new violations surfaced; no reformat was required.
- `mvn clean verify` is green: 289 tests pass and `ktlint:check` passes.